### PR TITLE
feat: ship reproducible evaluation CLI v0.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,5 +50,14 @@ jobs:
 
       - name: Run checked experiment
         working-directory: llm-evaluation-lab
-        run: python evaluation_lab.py
-
+        run: |
+          llm-eval \
+            --cases cases/anonymized/premature-parent-closure.md \
+            --format json \
+            --output /tmp/EVAL-CASE-001.json
+          llm-eval \
+            --cases cases/anonymized/premature-parent-closure.md \
+            --format markdown \
+            --output /tmp/EVAL-CASE-001.md
+          test -s /tmp/EVAL-CASE-001.json
+          test -s /tmp/EVAL-CASE-001.md

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 | Baseline accuracy | 20% |
 | With Closure Guard | 100% |
 | Known regression failures caught | 4/4 |
-| Evaluation tests | 4/4 |
+| Evaluation tests | 11/11 |
 
 **Status:** Experimental / reproducible artifact  
 **Evidence level:** E3 — reproducible public-safe evaluation
@@ -40,19 +40,28 @@ Clone both repositories as siblings. Requires Python 3.11 or later; no model API
 python -m pip install -e ../Companion-Mind
 python -m pip install -e .
 python -m unittest discover -s tests -v
-python evaluation_lab.py
+llm-eval --cases cases/anonymized/premature-parent-closure.md
+llm-eval \
+  --cases cases/anonymized/premature-parent-closure.md \
+  --format markdown \
+  --output evaluation-report.md
 ```
+
+The command validates the public-safe case contract, executes baseline and treatment,
+grades every variant, calculates metrics, enforces the regression gate, and emits a
+stable JSON or Markdown report. Exit code `1` means regression failure; invalid input
+or missing runtime dependencies return `2`.
 
 ## Evidence boundary
 
 ### Implemented
 
-- deterministic evaluation harness;
-- public-safe `EvaluationCase` fixture;
+- dependency-free `llm-eval` CLI and deterministic evaluation harness;
+- validated public-safe `EvaluationCase` loader;
 - baseline and mitigation comparison;
 - accuracy and premature-closure metrics;
-- checked result artifact;
-- known-bad regression probe.
+- JSON and Markdown report output;
+- checked result artifact and known-bad regression gate.
 
 ### Measured in the current demonstration
 
@@ -60,7 +69,7 @@ python evaluation_lab.py
 - guarded accuracy: **100%**;
 - premature closure rate: **100% → 0%**;
 - known recurrence variants caught: **4/4**;
-- evaluation tests: **4/4**.
+- evaluation tests: **11/11**.
 
 ### Not claimed
 
@@ -72,11 +81,11 @@ python evaluation_lab.py
 
 ## Artifact map
 
-- `evaluation_lab.py` — case, policies, metrics, and regression run
-- `cases/anonymized/premature-parent-closure.md` — public-safe case card
+- `evaluation_lab.py` — loader, policies, grader, metrics, regression gate, and CLI
+- `cases/anonymized/premature-parent-closure.md` — human-readable case card plus executable JSON fixture
 - `experiments/closure-guard-mitigation.md` — mitigation and decision rule
 - `results/EVAL-CASE-001.json` — checked deterministic result
-- `tests/test_evaluation.py` — reproducibility and regression assertions
+- `tests/test_evaluation.py` — loader, reproducibility, reporting, and regression assertions
 - `schemas/` — shared evaluation and mitigation contracts
 
 ## Roadmap
@@ -86,4 +95,3 @@ python evaluation_lab.py
 ## Privacy
 
 The case preserves the failure mechanism without publishing the private scene that revealed it. The repository contains no private Raw/L0 material, credentials, account data, client documents, personal records, or links to private archives.
-

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -15,5 +15,15 @@ Portfolio Status：**CURRENT ARTIFACT** · Evidence Level：**E3——可复现�
 
 这不是通用模型性能声明，而是第一个能被陌生人复跑的 Case → Failure → Metric → Mitigation → Guard → Regression 闭环。
 
-第三仓仍保留 concept growth、prior lock-in、world-model drift、longitudinal evolution 与 experimental timeline；failure taxonomy 只是公开接口，不取代纵向评估内核。
+## CLI 纵切
 
+```bash
+python -m pip install -e ../Companion-Mind
+python -m pip install -e .
+llm-eval --cases cases/anonymized/premature-parent-closure.md
+llm-eval --format markdown --output evaluation-report.md
+```
+
+`llm-eval` 依次完成 Case 加载与校验、基线/处理组执行、逐例评分、指标计算、回归门禁以及 JSON/Markdown 报告输出。回归失败返回退出码 `1`，输入或依赖错误返回 `2`。当前 11 项测试覆盖 fixture 同步、非法输入、实测指标、checked result、双格式报告、CLI 文件输出与退出码契约。
+
+第三仓仍保留 concept growth、prior lock-in、world-model drift、longitudinal evolution 与 experimental timeline；failure taxonomy 只是公开接口，不取代纵向评估内核。

--- a/cases/anonymized/premature-parent-closure.md
+++ b/cases/anonymized/premature-parent-closure.md
@@ -1,6 +1,6 @@
 # EVAL-CASE-001｜Premature Parent Closure
 
-Portfolio Status: **CURRENT ARTIFACT** · Privacy: **PUBLIC_SAFE_DERIVED**
+Portfolio Status: **CURRENT ARTIFACT** · Privacy: **PUBLIC_SAFE**
 
 ## Task
 
@@ -28,3 +28,70 @@ Five variants cover base order, reversed order, external waiting, unknown requir
 
 `MIT-CLOSURE-GUARD-001` is implemented in Companion-Mind as `CM-GUARD-001`.
 
+## Machine-readable fixture
+
+The CLI loads and validates this fenced JSON block when run from the repository. A
+packaged fallback keeps standalone installs runnable, and tests enforce structural
+parity between the two representations.
+
+```json
+{
+  "case_id": "EVAL-CASE-001",
+  "title": "Premature Parent Closure",
+  "run_id": "EVAL-RUN-001",
+  "mitigation_id": "MIT-CLOSURE-GUARD-001",
+  "safeguard_id": "CM-GUARD-001",
+  "task": "Decide whether a parent goal may be marked DONE from required child-task states.",
+  "inputs": [
+    {
+      "variant_id": "base-order",
+      "children": [
+        {"child_id": "quick-check", "status": "DONE"},
+        {"child_id": "qualification", "status": "OPEN"}
+      ],
+      "expected_close": false
+    },
+    {
+      "variant_id": "reordered-children",
+      "children": [
+        {"child_id": "qualification", "status": "OPEN"},
+        {"child_id": "quick-check", "status": "DONE"}
+      ],
+      "expected_close": false
+    },
+    {
+      "variant_id": "waiting-external",
+      "children": [
+        {"child_id": "quick-check", "status": "DONE"},
+        {"child_id": "access-grant", "status": "WAITING-EXTERNAL"}
+      ],
+      "expected_close": false
+    },
+    {
+      "variant_id": "unknown-required-state",
+      "children": [
+        {"child_id": "quick-check", "status": "DONE"},
+        {"child_id": "required-evidence", "status": "UNKNOWN"}
+      ],
+      "expected_close": false
+    },
+    {
+      "variant_id": "all-terminal",
+      "children": [
+        {"child_id": "quick-check", "status": "DONE"},
+        {"child_id": "qualification", "status": "DONE"}
+      ],
+      "expected_close": true
+    }
+  ],
+  "expected": {
+    "decision_rule": "Close only when every required child is terminal."
+  },
+  "metrics": [
+    "accuracy",
+    "premature_closure_rate",
+    "known_bad_failures_detected"
+  ],
+  "privacy": "PUBLIC_SAFE"
+}
+```

--- a/evaluation_lab.py
+++ b/evaluation_lab.py
@@ -1,13 +1,30 @@
-"""First public closed-loop evaluation for Companion-Mind's Closure Guard."""
+"""Reproducible CLI evaluation for Companion-Mind's Closure Guard."""
 
 from __future__ import annotations
 
+import argparse
+import json
+import os
+import re
+import sys
+import tempfile
 from dataclasses import asdict, dataclass
-from typing import Callable, Iterable, Mapping
+from pathlib import Path
+from typing import Callable, Iterable, Mapping, Sequence
 
+
+__version__ = "0.2.0"
 
 Child = Mapping[str, str]
+Case = Mapping[str, object]
 Policy = Callable[[Iterable[Child]], bool]
+
+DEFAULT_CASE_PATH = (
+    Path(__file__).resolve().parent
+    / "cases"
+    / "anonymized"
+    / "premature-parent-closure.md"
+)
 
 
 CASES: tuple[dict[str, object], ...] = (
@@ -55,12 +72,122 @@ CASES: tuple[dict[str, object], ...] = (
 
 
 @dataclass(frozen=True)
+class CaseSuite:
+    case_id: str
+    title: str
+    run_id: str
+    mitigation_id: str
+    safeguard_id: str
+    privacy: str
+    cases: tuple[dict[str, object], ...]
+
+
+@dataclass(frozen=True)
 class PolicyResult:
     policy: str
     accuracy: float
     premature_closure_rate: float
     failures: tuple[str, ...]
     predictions: tuple[dict[str, object], ...]
+
+
+BUILTIN_SUITE = CaseSuite(
+    case_id="EVAL-CASE-001",
+    title="Premature Parent Closure",
+    run_id="EVAL-RUN-001",
+    mitigation_id="MIT-CLOSURE-GUARD-001",
+    safeguard_id="CM-GUARD-001",
+    privacy="PUBLIC_SAFE",
+    cases=CASES,
+)
+
+
+def _read_case_document(path: Path) -> object:
+    text = path.read_text(encoding="utf-8")
+    if path.suffix.lower() in {".md", ".markdown"}:
+        match = re.search(r"```json\s*(\{.*?\})\s*```", text, flags=re.DOTALL)
+        if match is None:
+            raise ValueError(f"{path}: no fenced JSON case fixture found")
+        text = match.group(1)
+    return json.loads(text)
+
+
+def _required_text(document: Mapping[str, object], key: str, path: Path) -> str:
+    value = document.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{path}: {key!r} must be a non-empty string")
+    return value
+
+
+def _validate_cases(raw_cases: object, path: Path) -> tuple[dict[str, object], ...]:
+    if not isinstance(raw_cases, list) or not raw_cases:
+        raise ValueError(f"{path}: 'inputs' must be a non-empty array")
+
+    normalized: list[dict[str, object]] = []
+    seen: set[str] = set()
+    for index, raw_case in enumerate(raw_cases):
+        label = f"{path}: inputs[{index}]"
+        if not isinstance(raw_case, dict):
+            raise ValueError(f"{label} must be an object")
+
+        variant_id = raw_case.get("variant_id")
+        if not isinstance(variant_id, str) or not variant_id.strip():
+            raise ValueError(f"{label}.variant_id must be a non-empty string")
+        if variant_id in seen:
+            raise ValueError(f"{path}: duplicate variant_id {variant_id!r}")
+        seen.add(variant_id)
+
+        expected = raw_case.get("expected_close")
+        if not isinstance(expected, bool):
+            raise ValueError(f"{label}.expected_close must be boolean")
+
+        raw_children = raw_case.get("children")
+        if not isinstance(raw_children, list) or not raw_children:
+            raise ValueError(f"{label}.children must be a non-empty array")
+        children: list[dict[str, str]] = []
+        for child_index, raw_child in enumerate(raw_children):
+            child_label = f"{label}.children[{child_index}]"
+            if not isinstance(raw_child, dict):
+                raise ValueError(f"{child_label} must be an object")
+            child_id = raw_child.get("child_id")
+            status = raw_child.get("status")
+            if not isinstance(child_id, str) or not child_id.strip():
+                raise ValueError(f"{child_label}.child_id must be a non-empty string")
+            if not isinstance(status, str) or not status.strip():
+                raise ValueError(f"{child_label}.status must be a non-empty string")
+            children.append({"child_id": child_id, "status": status})
+
+        normalized.append(
+            {
+                "variant_id": variant_id,
+                "children": tuple(children),
+                "expected_close": expected,
+            }
+        )
+    return tuple(normalized)
+
+
+def load_case_suite(path: str | Path) -> CaseSuite:
+    """Load and validate a JSON or Markdown-embedded case suite."""
+
+    case_path = Path(path)
+    document = _read_case_document(case_path)
+    if not isinstance(document, dict):
+        raise ValueError(f"{case_path}: case document must be an object")
+
+    privacy = _required_text(document, "privacy", case_path)
+    if privacy not in {"PUBLIC", "PUBLIC_SAFE", "REDACTED"}:
+        raise ValueError(f"{case_path}: unsupported privacy value {privacy!r}")
+
+    return CaseSuite(
+        case_id=_required_text(document, "case_id", case_path),
+        title=_required_text(document, "title", case_path),
+        run_id=_required_text(document, "run_id", case_path),
+        mitigation_id=_required_text(document, "mitigation_id", case_path),
+        safeguard_id=_required_text(document, "safeguard_id", case_path),
+        privacy=privacy,
+        cases=_validate_cases(document.get("inputs"), case_path),
+    )
 
 
 def naive_any_done(children: Iterable[Child]) -> bool:
@@ -82,13 +209,21 @@ def closure_guard_policy(children: Iterable[Child]) -> bool:
     return ClosureGuard().evaluate(children).decision == "ACCEPT"
 
 
-def evaluate_policy(name: str, policy: Policy) -> PolicyResult:
+def evaluate_policy(
+    name: str,
+    policy: Policy,
+    cases: Iterable[Case] = CASES,
+) -> PolicyResult:
+    case_list = tuple(cases)
+    if not case_list:
+        raise ValueError("at least one evaluation case is required")
+
     predictions: list[dict[str, object]] = []
     failures: list[str] = []
     negatives = 0
     premature = 0
 
-    for case in CASES:
+    for case in case_list:
         variant_id = str(case["variant_id"])
         expected = bool(case["expected_close"])
         predicted = policy(case["children"])  # type: ignore[arg-type]
@@ -110,23 +245,25 @@ def evaluate_policy(name: str, policy: Policy) -> PolicyResult:
 
     return PolicyResult(
         policy=name,
-        accuracy=(len(CASES) - len(failures)) / len(CASES),
-        premature_closure_rate=premature / negatives,
+        accuracy=(len(case_list) - len(failures)) / len(case_list),
+        premature_closure_rate=premature / negatives if negatives else 0.0,
         failures=tuple(failures),
         predictions=tuple(predictions),
     )
 
 
-def run_experiment() -> dict[str, object]:
-    baseline = evaluate_policy("naive_any_done", naive_any_done)
-    treatment = evaluate_policy("CM-GUARD-001", closure_guard_policy)
-    regression_probe = evaluate_policy("known_bad_regression_probe", naive_any_done)
+def run_experiment(suite: CaseSuite = BUILTIN_SUITE) -> dict[str, object]:
+    baseline = evaluate_policy("naive_any_done", naive_any_done, suite.cases)
+    treatment = evaluate_policy(suite.safeguard_id, closure_guard_policy, suite.cases)
+    regression_probe = evaluate_policy(
+        "known_bad_regression_probe", naive_any_done, suite.cases
+    )
     return {
-        "run_id": "EVAL-RUN-001",
-        "case_id": "EVAL-CASE-001",
-        "mitigation_id": "MIT-CLOSURE-GUARD-001",
-        "safeguard_id": "CM-GUARD-001",
-        "fixture_count": len(CASES),
+        "run_id": suite.run_id,
+        "case_id": suite.case_id,
+        "mitigation_id": suite.mitigation_id,
+        "safeguard_id": suite.safeguard_id,
+        "fixture_count": len(suite.cases),
         "baseline": asdict(baseline),
         "treatment": asdict(treatment),
         "accuracy_delta": treatment.accuracy - baseline.accuracy,
@@ -145,12 +282,135 @@ def run_experiment() -> dict[str, object]:
     }
 
 
-def main() -> None:
-    import json
+def render_report(result: Mapping[str, object], output_format: str) -> str:
+    if output_format == "json":
+        return json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+    if output_format != "markdown":
+        raise ValueError(f"unsupported output format: {output_format}")
 
-    print(json.dumps(run_experiment(), ensure_ascii=False, indent=2, sort_keys=True))
+    baseline = result["baseline"]
+    treatment = result["treatment"]
+    regression = result["regression"]
+    if not isinstance(baseline, Mapping) or not isinstance(treatment, Mapping):
+        raise ValueError("result is missing policy metrics")
+    if not isinstance(regression, Mapping):
+        raise ValueError("result is missing regression metrics")
+
+    return "\n".join(
+        (
+            f"# {result['case_id']} Evaluation Report",
+            "",
+            f"- Run: `{result['run_id']}`",
+            f"- Mitigation: `{result['mitigation_id']}`",
+            f"- Safeguard: `{result['safeguard_id']}`",
+            f"- Evidence: `{result['evidence_level']}`",
+            "",
+            "| Policy | Accuracy | Premature closure rate | Failures |",
+            "|---|---:|---:|---:|",
+            f"| Baseline | {float(baseline['accuracy']):.0%} | "
+            f"{float(baseline['premature_closure_rate']):.0%} | "
+            f"{len(baseline['failures'])} |",
+            f"| Closure Guard | {float(treatment['accuracy']):.0%} | "
+            f"{float(treatment['premature_closure_rate']):.0%} | "
+            f"{len(treatment['failures'])} |",
+            "",
+            "## Regression",
+            "",
+            f"**{regression['status']}** — known-bad failures detected: "
+            f"{regression['known_bad_failures_detected']}; guard failures: "
+            f"{regression['guard_failures']}.",
+            "",
+            "## Evidence boundary",
+            "",
+            *[f"- {item}" for item in result["limitations"]],
+            "",
+        )
+    )
+
+
+def write_report(path: str | Path, content: str) -> None:
+    """Write a report atomically, creating its parent directory when needed."""
+
+    output_path = Path(path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    temporary_name: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=output_path.parent,
+            prefix=f".{output_path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as temporary:
+            temporary.write(content)
+            temporary_name = temporary.name
+        os.replace(temporary_name, output_path)
+    finally:
+        if temporary_name and os.path.exists(temporary_name):
+            os.unlink(temporary_name)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="llm-eval",
+        description=(
+            "Load public-safe cases, run baseline and Closure Guard policies, "
+            "grade outcomes, calculate metrics, and enforce regression checks."
+        ),
+    )
+    parser.add_argument(
+        "--cases",
+        type=Path,
+        help=(
+            "JSON or Markdown case suite. If omitted, load the checked case card "
+            "when available and otherwise use the built-in EVAL-CASE-001 fixture."
+        ),
+    )
+    parser.add_argument(
+        "--format",
+        choices=("json", "markdown"),
+        default="json",
+        help="report format (default: json)",
+    )
+    parser.add_argument("--output", type=Path, help="write the report to this path")
+    parser.add_argument(
+        "--allow-regression",
+        action="store_true",
+        help="return exit code 0 even when the regression gate fails",
+    )
+    parser.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        if args.cases:
+            suite = load_case_suite(args.cases)
+        elif DEFAULT_CASE_PATH.exists():
+            suite = load_case_suite(DEFAULT_CASE_PATH)
+        else:
+            suite = BUILTIN_SUITE
+        result = run_experiment(suite)
+        report = render_report(result, args.format)
+        if args.output:
+            write_report(args.output, report)
+        else:
+            print(report, end="")
+    except (OSError, ValueError, RuntimeError, json.JSONDecodeError) as exc:
+        print(f"llm-eval: error: {exc}", file=sys.stderr)
+        return 2
+
+    regression = result["regression"]
+    if (
+        isinstance(regression, Mapping)
+        and regression.get("status") != "PASS"
+        and not args.allow_regression
+    ):
+        return 1
+    return 0
 
 
 if __name__ == "__main__":
-    main()
-
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,11 +4,13 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-evaluation-lab"
-version = "0.1.0"
+version = "0.2.0"
 description = "Runnable public-safe LLM failure evaluation harness"
 requires-python = ">=3.11"
 dependencies = []
 
+[project.scripts]
+llm-eval = "evaluation_lab:main"
+
 [tool.setuptools]
 py-modules = ["evaluation_lab"]
-

--- a/schemas/evaluation_case.schema.json
+++ b/schemas/evaluation_case.schema.json
@@ -3,12 +3,51 @@
   "$id": "https://example.org/schemas/evaluation-case.schema.json",
   "title": "LLM Evaluation Case",
   "type": "object",
-  "required": ["case_id", "title", "task", "inputs", "expected", "metrics", "privacy"],
+  "required": [
+    "case_id",
+    "title",
+    "run_id",
+    "mitigation_id",
+    "safeguard_id",
+    "task",
+    "inputs",
+    "expected",
+    "metrics",
+    "privacy"
+  ],
   "properties": {
     "case_id": {"type": "string"},
     "title": {"type": "string"},
     "task": {"type": "string"},
-    "inputs": {"type": "array", "items": {"type": "object"}},
+    "run_id": {"type": "string"},
+    "mitigation_id": {"type": "string"},
+    "safeguard_id": {"type": "string"},
+    "inputs": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["variant_id", "children", "expected_close"],
+        "properties": {
+          "variant_id": {"type": "string", "minLength": 1},
+          "children": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "object",
+              "required": ["child_id", "status"],
+              "properties": {
+                "child_id": {"type": "string", "minLength": 1},
+                "status": {"type": "string", "minLength": 1}
+              },
+              "additionalProperties": false
+            }
+          },
+          "expected_close": {"type": "boolean"}
+        },
+        "additionalProperties": false
+      }
+    },
     "expected": {"type": "object"},
     "metrics": {"type": "array", "items": {"type": "string"}},
     "failure_modes": {"type": "array", "items": {"type": "string"}},

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -1,12 +1,27 @@
+import json
+import io
+import tempfile
 import unittest
+from contextlib import redirect_stderr
+from pathlib import Path
+from unittest.mock import patch
 
 from evaluation_lab import (
+    BUILTIN_SUITE,
     CASES,
+    DEFAULT_CASE_PATH,
     closure_guard_policy,
     evaluate_policy,
+    load_case_suite,
+    main,
     naive_any_done,
+    render_report,
     run_experiment,
 )
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CHECKED_RESULT = ROOT / "results" / "EVAL-CASE-001.json"
 
 
 class EvaluationHarnessTest(unittest.TestCase):
@@ -14,6 +29,39 @@ class EvaluationHarnessTest(unittest.TestCase):
         expected = [bool(case["expected_close"]) for case in CASES]
         self.assertIn(False, expected)
         self.assertIn(True, expected)
+
+    def test_case_card_loads_and_matches_packaged_fallback(self) -> None:
+        suite = load_case_suite(DEFAULT_CASE_PATH)
+        self.assertEqual(suite.case_id, "EVAL-CASE-001")
+        self.assertEqual(suite.privacy, "PUBLIC_SAFE")
+        self.assertEqual(suite.cases, BUILTIN_SUITE.cases)
+
+    def test_loader_rejects_duplicate_variant_ids(self) -> None:
+        document = {
+            "case_id": "EVAL-CASE-BAD",
+            "title": "Invalid duplicate fixture",
+            "run_id": "EVAL-RUN-BAD",
+            "mitigation_id": "MIT-BAD",
+            "safeguard_id": "GUARD-BAD",
+            "privacy": "PUBLIC_SAFE",
+            "inputs": [
+                {
+                    "variant_id": "duplicate",
+                    "children": [{"child_id": "a", "status": "DONE"}],
+                    "expected_close": True,
+                },
+                {
+                    "variant_id": "duplicate",
+                    "children": [{"child_id": "b", "status": "OPEN"}],
+                    "expected_close": False,
+                },
+            ],
+        }
+        with tempfile.TemporaryDirectory() as temporary:
+            path = Path(temporary) / "invalid.json"
+            path.write_text(json.dumps(document), encoding="utf-8")
+            with self.assertRaisesRegex(ValueError, "duplicate variant_id"):
+                load_case_suite(path)
 
     def test_baseline_reproduces_the_failure(self) -> None:
         result = evaluate_policy("baseline", naive_any_done)
@@ -28,12 +76,61 @@ class EvaluationHarnessTest(unittest.TestCase):
         self.assertEqual(result.failures, ())
 
     def test_regression_run_detects_known_bad_recurrence(self) -> None:
-        result = run_experiment()
+        result = run_experiment(load_case_suite(DEFAULT_CASE_PATH))
         self.assertEqual(result["regression"]["status"], "PASS")
         self.assertEqual(result["regression"]["known_bad_failures_detected"], 4)
         self.assertEqual(result["regression"]["guard_failures"], 0)
 
+    def test_json_report_matches_checked_result(self) -> None:
+        result = run_experiment(load_case_suite(DEFAULT_CASE_PATH))
+        generated = json.loads(render_report(result, "json"))
+        expected = json.loads(CHECKED_RESULT.read_text(encoding="utf-8"))
+        self.assertEqual(generated, expected)
+
+    def test_markdown_report_contains_metrics_and_regression_status(self) -> None:
+        result = run_experiment(load_case_suite(DEFAULT_CASE_PATH))
+        report = render_report(result, "markdown")
+        self.assertIn("| Baseline | 20% | 100% | 4 |", report)
+        self.assertIn("| Closure Guard | 100% | 0% | 0 |", report)
+        self.assertIn("**PASS**", report)
+
+    def test_cli_writes_an_atomic_markdown_report(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            output = Path(temporary) / "reports" / "evaluation.md"
+            exit_code = main(
+                [
+                    "--cases",
+                    str(DEFAULT_CASE_PATH),
+                    "--format",
+                    "markdown",
+                    "--output",
+                    str(output),
+                ]
+            )
+            self.assertEqual(exit_code, 0)
+            self.assertTrue(output.is_file())
+            self.assertIn("EVAL-CASE-001", output.read_text(encoding="utf-8"))
+
+    def test_cli_returns_2_for_invalid_input(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            invalid = Path(temporary) / "invalid.json"
+            invalid.write_text("{}", encoding="utf-8")
+            error = io.StringIO()
+            with redirect_stderr(error):
+                exit_code = main(["--cases", str(invalid)])
+            self.assertEqual(exit_code, 2)
+            self.assertIn("must be a non-empty string", error.getvalue())
+
+    def test_cli_returns_1_when_regression_gate_fails(self) -> None:
+        failed_result = run_experiment(BUILTIN_SUITE)
+        failed_result["regression"]["status"] = "FAIL"
+        with tempfile.TemporaryDirectory() as temporary:
+            output = Path(temporary) / "failed.json"
+            with patch("evaluation_lab.run_experiment", return_value=failed_result):
+                exit_code = main(["--output", str(output)])
+            self.assertEqual(exit_code, 1)
+            self.assertTrue(output.is_file())
+
 
 if __name__ == "__main__":
     unittest.main()
-


### PR DESCRIPTION
## Problem

The first closed loop was reproducible through a Python module, but it did not yet expose the roadmap's full executable path as a stable CLI:

`load cases → baseline/treatment → grade → metrics → regression → report`.

## What changed

- add the dependency-free `llm-eval` console command;
- load and validate JSON or Markdown-embedded public-safe case suites;
- execute the known-bad baseline and Companion-Mind Closure Guard treatment;
- grade every variant and calculate accuracy / premature-closure metrics;
- fail closed through a regression exit-code contract;
- emit deterministic JSON or human-readable Markdown reports;
- make the existing Case Card carry the executable fixture while preserving the 15-file repository boundary;
- tighten the EvaluationCase schema and run the installed CLI in GitHub Actions.

## How to reproduce

```bash
python -m pip install -e ../Companion-Mind
python -m pip install -e .
python -m unittest discover -s tests -v
llm-eval --cases cases/anonymized/premature-parent-closure.md
llm-eval \
  --cases cases/anonymized/premature-parent-closure.md \
  --format markdown \
  --output evaluation-report.md
```

## Measured result

The checked five-variant demonstration remains unchanged:

- baseline accuracy: **20%**;
- guarded accuracy: **100%**;
- premature closure rate: **100% → 0%**;
- known-bad failures caught: **4/4**;
- guard failures: **0**.

## Tests

Local clean-venv acceptance:

- **11/11** unit and contract tests passed;
- installed `llm-eval 0.2.0` executed successfully;
- generated JSON matched `results/EVAL-CASE-001.json` semantically;
- Markdown report was generated;
- schema parsing, privacy scan, and 15-file count passed.

GitHub Actions is the merge gate for this draft.

## Privacy boundary

Only the existing synthetic, public-safe failure mechanism is used. No private Raw/L0 material, credentials, account data, client data, personal records, or links to private archives are added.

## Known limitations

- deterministic structural fixture only;
- no live LLM calls;
- no production traffic;
- no cross-model generalization or benchmark-validity claim;
- the treatment requires the sibling Companion-Mind package.

## Relationship to the other core repo

This repository **proves whether the protection works**. [Companion-Mind](https://github.com/aerenkolstein-code/Companion-Mind) **implements the protection** as `CM-GUARD-001`.

## Review scope

This is the first engineering slice of the dual-core roadmap. It intentionally excludes Stateful Runtime expansion, executable cross-repo integration beyond the existing guard adapter, and the Historical Failure Benchmark.