### PR TITLE
Persistent Experiment Tracking v0.5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    env:
+      EVAL_GIT_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
     steps:
       - name: Check out evaluation repository
         uses: actions/checkout@v4
@@ -73,6 +75,12 @@ jobs:
             --suite historical \
             --cases cases/anonymized/premature-parent-closure.md \
             --format json \
+            --store /tmp/eval-runs.sqlite3 \
+            --run-id "CI-HFB-${EVAL_GIT_COMMIT}" \
+            --model deterministic-reference \
+            --prompt-version hfb-v1 \
+            --git-commit "$EVAL_GIT_COMMIT" \
+            --log-json \
             --output /tmp/HISTORICAL-FAILURE-BENCHMARK-v1.json
           llm-eval \
             --suite historical \
@@ -81,3 +89,9 @@ jobs:
             --output /tmp/HISTORICAL-FAILURE-BENCHMARK-v1.md
           test -s /tmp/HISTORICAL-FAILURE-BENCHMARK-v1.json
           test -s /tmp/HISTORICAL-FAILURE-BENCHMARK-v1.md
+          test -s /tmp/eval-runs.sqlite3
+          llm-eval \
+            --store /tmp/eval-runs.sqlite3 \
+            --list-runs 1 \
+            --output /tmp/experiment-runs.json
+          python -c 'import json; rows=json.load(open("/tmp/experiment-runs.json")); assert len(rows)==1; assert rows[0]["regression_status"]=="PASS"; assert rows[0]["git_commit"]'

--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,5 @@ dist/
 /l0/
 /credentials/
 *.env
-
+*.sqlite
+*.sqlite3

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 | Baseline accuracy | 20% |
 | With Closure Guard | 100% |
 | Known regression failures caught | 4/4 |
-| Evaluation tests | 22/22 |
+| Evaluation tests | 27/27 |
 | Executable MitigationSpec | Runtime-validated |
 
 **Status:** Experimental / reproducible artifact  
@@ -84,6 +84,33 @@ grades every variant, calculates metrics, enforces the regression gate, and emit
 stable JSON or Markdown report. Exit code `1` means regression failure; invalid input
 or missing runtime dependencies return `2`.
 
+## Persistent experiment tracking v0.5
+
+Runs can now be written atomically to a dependency-free SQLite store. The store
+keeps immutable execution identity, suite version, model/policy, prompt version,
+metrics, latency, token cost, git commit, UTC timestamp and the canonical result
+JSON. A duplicate `run_id` is rejected instead of silently overwriting evidence.
+
+```bash
+llm-eval \
+  --suite historical \
+  --cases cases/anonymized/premature-parent-closure.md \
+  --store /tmp/eval-runs.sqlite3 \
+  --model deterministic-reference \
+  --prompt-version hfb-v1 \
+  --git-commit "$(git rev-parse HEAD)" \
+  --log-json \
+  --output /tmp/historical-run.json
+
+llm-eval \
+  --store /tmp/eval-runs.sqlite3 \
+  --list-runs 10
+```
+
+Structured lifecycle events are emitted to `stderr`, leaving the JSON or
+Markdown report on `stdout` or in `--output`. SQLite files are runtime evidence
+and are ignored by git; they are not checked into the public repository.
+
 ## Executable integration v0.3
 
 The experiment now owns a complete `mitigation-spec/v1` contract, validates it,
@@ -106,6 +133,8 @@ boundary explicit: Eval Lab specifies and verifies; Companion-Mind implements.
 - checked result artifact and known-bad regression gate.
 - validated 12-cluster, 24-case Historical Failure Benchmark;
 - one uniform evidence-and-constraint gate with zero per-observation rules.
+- immutable SQLite experiment-run persistence and metadata query;
+- structured JSON lifecycle logging.
 
 ### Measured in the current demonstration
 
@@ -113,12 +142,13 @@ boundary explicit: Eval Lab specifies and verifies; Companion-Mind implements.
 - guarded accuracy: **100%**;
 - premature closure rate: **100% → 0%**;
 - known recurrence variants caught: **4/4**;
-- evaluation tests: **15/15**;
 - runtime integration status: **PASS**.
 - historical benchmark baseline: **50%**;
 - uniform constraint gate: **100%**;
 - historical traps caught: **12/12**;
-- evaluation tests: **22/22**.
+- evaluation tests: **27/27**;
+- SQLite persistence and readback: **PASS**;
+- duplicate run protection: **PASS**.
 
 ### Not claimed
 
@@ -139,7 +169,7 @@ boundary explicit: Eval Lab specifies and verifies; Companion-Mind implements.
 
 ## Roadmap
 
-**Operationalization** — planned SQL/FastAPI/Docker, observability and experiment tracking after the current benchmark contract is stable.
+**Operationalization** — SQLite experiment tracking and structured logging are implemented. Next: a read-only FastAPI query surface, followed by Docker reproducibility.
 
 ## Privacy
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -29,7 +29,7 @@ companion-mind validate-mitigation --mitigation-spec /tmp/mitigation.json
 
 `llm-eval` 现在负责校验并输出完整的 `mitigation-spec/v1`，再用它实例化 Companion-Mind 的真实 `ClosureGuard`。报告同时记录 runtime 实际加载的 mitigation ID、safeguard ID、schema version 与 canonical SHA-256 fingerprint，从而证明“写入评测报告的配置”与“运行时真正执行的配置”一致。
 
-当前 **22/22 tests** 覆盖 Case/Spec 同步、非法规范、状态集合冲突、真实 runtime 回归、checked result、历史机制簇、最小对照、隐私定位符、双格式报告、CLI 原子输出与退出码契约。
+当前 **27/27 tests** 覆盖 Case/Spec 同步、非法规范、状态集合冲突、真实 runtime 回归、checked result、历史机制簇、最小对照、隐私定位符、双套 suite 的 SQLite 持久化、重复 run 防覆盖、结构化日志、双格式报告、CLI 原子输出与退出码契约。
 
 ## Historical Failure Benchmark v0.4
 
@@ -41,6 +41,10 @@ llm-eval \
   --cases cases/anonymized/premature-parent-closure.md
 ```
 
-当前确定性基准：置信表面基线 **50%**，统一证据—约束门 **100%**，已抓住 **12/12** 个已知陷阱，逐观察规则数 **0**。全仓测试现为 **22/22**。这些数字只描述合成结构基准，不代表真实模型泛化、生产可靠性或科学 benchmark 有效性。
+当前确定性基准：置信表面基线 **50%**，统一证据—约束门 **100%**，已抓住 **12/12** 个已知陷阱，逐观察规则数 **0**。全仓测试现为 **27/27**。这些数字只描述合成结构基准，不代表真实模型泛化、生产可靠性或科学 benchmark 有效性。
+
+## Persistent Experiment Tracking v0.5
+
+`llm-eval` 现在可以把每次运行原子写入 SQLite，记录 run ID、suite version、model/policy、prompt version、metrics、latency、token cost、git commit、UTC timestamp 与 canonical result JSON。`run_id` 不可变，重复写入会被拒绝；`--list-runs` 可回读元数据，`--log-json` 输出结构化生命周期日志。数据库属于运行证据，默认被 git 忽略，不进入公开仓库。
 
 第三仓仍保留 concept growth、prior lock-in、world-model drift、longitudinal evolution 与 experimental timeline；failure taxonomy 只是公开接口，不取代纵向评估内核。

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -23,3 +23,17 @@ label. A new mechanism can use the same gate when it exposes evidence state and
 explicit constraint statuses.
 
 Future model-based runs will keep the same separation between case owner, policy under test, grader, mitigation and checked-in result.
+
+## Experiment records
+
+An experiment run is immutable evidence, not a mutable dashboard row. The SQLite
+store uses `run_id` as the primary key and rejects duplicate IDs. Every record
+keeps the case-suite identity, model or policy, prompt version, git commit, UTC
+timestamp, latency, token cost, baseline and treatment accuracy, regression
+status, and canonical result JSON. Listing returns indexed metadata without
+dumping the stored result payload.
+
+Structured lifecycle logs use one JSON object per line and remain separate from
+the report channel: `run_started`, `run_completed`, `run_persisted`, or
+`run_failed`. This preserves machine-readable observability without changing the
+deterministic report contract when tracking is not requested.

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -12,3 +12,8 @@ CI checks the checked fixture for known private locator patterns. This check is 
 release guard, not a claim that automated scanning can replace human review.
 
 No file may expose or link to private Raw/L0, relationship or family records, adult material, medical/financial data, accounts, platform assessments, client material, unpublished manuscripts or internal archive/control documents. Uncertain material remains private.
+
+SQLite stores and JSON logs may contain experiment metadata and full public-safe
+result payloads. They are runtime evidence, not repository fixtures: database
+files are ignored by git, and operators must not pass private prompts, credentials
+or archive locations through model, prompt-version, git-commit or run-ID fields.

--- a/evaluation_lab.py
+++ b/evaluation_lab.py
@@ -6,14 +6,18 @@ import argparse
 import json
 import os
 import re
+import sqlite3
 import sys
 import tempfile
+import time
+import uuid
 from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Callable, Iterable, Mapping, Sequence
 
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"
 
 Child = Mapping[str, str]
 Case = Mapping[str, object]
@@ -888,6 +892,204 @@ def render_report(result: Mapping[str, object], output_format: str) -> str:
     )
 
 
+STORE_SCHEMA_VERSION = 1
+
+
+def _utc_timestamp() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace(
+        "+00:00", "Z"
+    )
+
+
+def generate_run_id() -> str:
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    return f"RUN-{timestamp}-{uuid.uuid4().hex[:8]}"
+
+
+def _policy_accuracy(result: Mapping[str, object], key: str) -> float:
+    policy = result.get(key)
+    if not isinstance(policy, Mapping):
+        raise ValueError(f"result is missing {key!r} policy metrics")
+    accuracy = policy.get("accuracy")
+    if not isinstance(accuracy, (int, float)) or isinstance(accuracy, bool):
+        raise ValueError(f"result {key!r} accuracy must be numeric")
+    return float(accuracy)
+
+
+def _initialize_store(connection: sqlite3.Connection) -> None:
+    version = int(connection.execute("PRAGMA user_version").fetchone()[0])
+    if version not in {0, STORE_SCHEMA_VERSION}:
+        raise ValueError(
+            f"unsupported experiment store schema version {version}"
+        )
+    connection.execute(
+        """
+        CREATE TABLE IF NOT EXISTS experiment_runs (
+            run_id TEXT PRIMARY KEY,
+            suite TEXT NOT NULL,
+            case_suite_version TEXT NOT NULL,
+            model TEXT NOT NULL,
+            prompt_version TEXT NOT NULL,
+            git_commit TEXT NOT NULL,
+            created_at_utc TEXT NOT NULL,
+            latency_ms REAL NOT NULL CHECK (latency_ms >= 0),
+            token_cost REAL NOT NULL CHECK (token_cost >= 0),
+            baseline_accuracy REAL NOT NULL,
+            treatment_accuracy REAL NOT NULL,
+            regression_status TEXT NOT NULL,
+            result_json TEXT NOT NULL
+        )
+        """
+    )
+    if version == 0:
+        connection.execute(f"PRAGMA user_version = {STORE_SCHEMA_VERSION}")
+
+
+def persist_experiment_run(
+    store_path: str | Path,
+    result: Mapping[str, object],
+    *,
+    suite: str,
+    model: str,
+    prompt_version: str,
+    git_commit: str,
+    latency_ms: float,
+    token_cost: float = 0.0,
+    created_at_utc: str | None = None,
+) -> dict[str, object]:
+    """Atomically persist one immutable experiment run in SQLite."""
+
+    path = Path(store_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    run_id = str(result.get("run_id", "")).strip()
+    if not run_id:
+        raise ValueError("result run_id must be a non-empty string")
+    if suite not in {"closure", "historical"}:
+        raise ValueError(f"unsupported suite {suite!r}")
+    for label, value in {
+        "model": model,
+        "prompt_version": prompt_version,
+        "git_commit": git_commit,
+    }.items():
+        if not value.strip():
+            raise ValueError(f"{label} must be a non-empty string")
+    if latency_ms < 0 or token_cost < 0:
+        raise ValueError("latency_ms and token_cost must be non-negative")
+
+    case_suite_version = str(
+        result.get("benchmark_id") or result.get("case_id") or ""
+    ).strip()
+    if not case_suite_version:
+        raise ValueError("result is missing case-suite identity")
+    regression = result.get("regression")
+    if not isinstance(regression, Mapping):
+        raise ValueError("result is missing regression status")
+    regression_status = str(regression.get("status", "")).strip()
+    if not regression_status:
+        raise ValueError("result regression status must be non-empty")
+    created = created_at_utc or _utc_timestamp()
+    canonical_result = json.dumps(
+        result,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+    values = (
+        run_id,
+        suite,
+        case_suite_version,
+        model.strip(),
+        prompt_version.strip(),
+        git_commit.strip(),
+        created,
+        float(latency_ms),
+        float(token_cost),
+        _policy_accuracy(result, "baseline"),
+        _policy_accuracy(result, "treatment"),
+        regression_status,
+        canonical_result,
+    )
+    try:
+        with sqlite3.connect(path) as connection:
+            _initialize_store(connection)
+            connection.execute(
+                """
+                INSERT INTO experiment_runs (
+                    run_id, suite, case_suite_version, model, prompt_version,
+                    git_commit, created_at_utc, latency_ms, token_cost,
+                    baseline_accuracy, treatment_accuracy, regression_status,
+                    result_json
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                values,
+            )
+    except sqlite3.IntegrityError as exc:
+        raise ValueError(f"experiment run {run_id!r} already exists") from exc
+    except sqlite3.DatabaseError as exc:
+        raise ValueError(f"experiment store error: {exc}") from exc
+
+    return {
+        "run_id": run_id,
+        "suite": suite,
+        "case_suite_version": case_suite_version,
+        "model": model.strip(),
+        "prompt_version": prompt_version.strip(),
+        "git_commit": git_commit.strip(),
+        "created_at_utc": created,
+        "latency_ms": float(latency_ms),
+        "token_cost": float(token_cost),
+        "baseline_accuracy": _policy_accuracy(result, "baseline"),
+        "treatment_accuracy": _policy_accuracy(result, "treatment"),
+        "regression_status": regression_status,
+    }
+
+
+def list_experiment_runs(
+    store_path: str | Path, limit: int = 20
+) -> list[dict[str, object]]:
+    """Return newest experiment metadata without exposing stored result payloads."""
+
+    if limit < 1 or limit > 1000:
+        raise ValueError("run list limit must be between 1 and 1000")
+    path = Path(store_path)
+    if not path.exists():
+        raise ValueError(f"experiment store does not exist: {path}")
+    try:
+        with sqlite3.connect(path) as connection:
+            _initialize_store(connection)
+            connection.row_factory = sqlite3.Row
+            rows = connection.execute(
+                """
+                SELECT run_id, suite, case_suite_version, model,
+                       prompt_version, git_commit, created_at_utc,
+                       latency_ms, token_cost, baseline_accuracy,
+                       treatment_accuracy, regression_status
+                FROM experiment_runs
+                ORDER BY created_at_utc DESC, run_id DESC
+                LIMIT ?
+                """,
+                (limit,),
+            ).fetchall()
+    except sqlite3.DatabaseError as exc:
+        raise ValueError(f"experiment store error: {exc}") from exc
+    return [dict(row) for row in rows]
+
+
+def emit_json_log(enabled: bool, event: str, **fields: object) -> None:
+    if not enabled:
+        return
+    print(
+        json.dumps(
+            {"timestamp": _utc_timestamp(), "event": event, **fields},
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        ),
+        file=sys.stderr,
+    )
+
+
 def write_report(path: str | Path, content: str) -> None:
     """Write a report atomically, creating its parent directory when needed."""
 
@@ -924,6 +1126,47 @@ def build_parser() -> argparse.ArgumentParser:
         choices=("closure", "historical"),
         default="closure",
         help="evaluation suite to run (default: closure)",
+    )
+    parser.add_argument(
+        "--store",
+        type=Path,
+        help="persist immutable experiment metadata and result JSON in SQLite",
+    )
+    parser.add_argument(
+        "--run-id",
+        help="execution run ID; generated automatically when --store is used",
+    )
+    parser.add_argument(
+        "--model",
+        default="deterministic-reference",
+        help="model or policy identity recorded with a stored run",
+    )
+    parser.add_argument(
+        "--prompt-version",
+        default="none",
+        help="prompt version recorded with a stored run",
+    )
+    parser.add_argument(
+        "--git-commit",
+        default=os.environ.get("GITHUB_SHA", "unknown"),
+        help="git commit recorded with a stored run (defaults to GITHUB_SHA)",
+    )
+    parser.add_argument(
+        "--token-cost",
+        type=float,
+        default=0.0,
+        help="token or provider cost recorded with a stored run (default: 0)",
+    )
+    parser.add_argument(
+        "--log-json",
+        action="store_true",
+        help="emit structured run lifecycle events to stderr",
+    )
+    parser.add_argument(
+        "--list-runs",
+        type=int,
+        metavar="N",
+        help="list the newest N runs from --store instead of evaluating",
     )
     parser.add_argument(
         "--cases",
@@ -964,7 +1207,37 @@ def build_parser() -> argparse.ArgumentParser:
 
 def main(argv: Sequence[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
+    started_at_utc = _utc_timestamp()
+    started = time.perf_counter()
     try:
+        if args.list_runs is not None:
+            if args.store is None:
+                raise ValueError("--list-runs requires --store")
+            runs = list_experiment_runs(args.store, args.list_runs)
+            content = json.dumps(
+                runs, ensure_ascii=False, indent=2, sort_keys=True
+            ) + "\n"
+            if args.output:
+                write_report(args.output, content)
+            else:
+                print(content, end="")
+            emit_json_log(
+                args.log_json,
+                "runs_listed",
+                store=str(args.store),
+                count=len(runs),
+            )
+            return 0
+
+        effective_run_id = args.run_id or (
+            generate_run_id() if args.store is not None else None
+        )
+        emit_json_log(
+            args.log_json,
+            "run_started",
+            suite=args.suite,
+            run_id=effective_run_id,
+        )
         case_path = args.cases or DEFAULT_CASE_PATH
         if args.suite == "historical":
             if not case_path.exists():
@@ -1000,12 +1273,61 @@ def main(argv: Sequence[str] | None = None) -> int:
                     + "\n",
                 )
             result = run_experiment(suite, mitigation_spec)
+        latency_ms = (time.perf_counter() - started) * 1000
+        if effective_run_id is not None:
+            result = dict(result)
+            result["run_id"] = effective_run_id
+            result["experiment"] = {
+                "model": args.model,
+                "prompt_version": args.prompt_version,
+                "git_commit": args.git_commit,
+                "created_at_utc": started_at_utc,
+                "latency_ms": latency_ms,
+                "token_cost": args.token_cost,
+            }
+        regression = result.get("regression")
+        regression_status = (
+            regression.get("status") if isinstance(regression, Mapping) else None
+        )
+        emit_json_log(
+            args.log_json,
+            "run_completed",
+            suite=args.suite,
+            run_id=result.get("run_id"),
+            latency_ms=latency_ms,
+            regression_status=regression_status,
+        )
+        if args.store is not None:
+            record = persist_experiment_run(
+                args.store,
+                result,
+                suite=args.suite,
+                model=args.model,
+                prompt_version=args.prompt_version,
+                git_commit=args.git_commit,
+                latency_ms=latency_ms,
+                token_cost=args.token_cost,
+                created_at_utc=started_at_utc,
+            )
+            emit_json_log(
+                args.log_json,
+                "run_persisted",
+                store=str(args.store),
+                run_id=record["run_id"],
+                case_suite_version=record["case_suite_version"],
+            )
         report = render_report(result, args.format)
         if args.output:
             write_report(args.output, report)
         else:
             print(report, end="")
     except (OSError, ValueError, RuntimeError, json.JSONDecodeError) as exc:
+        emit_json_log(
+            args.log_json,
+            "run_failed",
+            suite=args.suite,
+            error=str(exc),
+        )
         print(f"llm-eval: error: {exc}", file=sys.stderr)
         return 2
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-evaluation-lab"
-version = "0.4.0"
-description = "Runnable public-safe LLM failure benchmark and evaluation harness"
+version = "0.5.0"
+description = "Public-safe LLM evaluation harness with persistent experiment tracking"
 requires-python = ">=3.11"
 dependencies = []
 

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -1,5 +1,6 @@
 import json
 import io
+import sqlite3
 import tempfile
 import unittest
 from contextlib import redirect_stderr
@@ -20,8 +21,10 @@ from evaluation_lab import (
     load_case_suite,
     load_historical_benchmark,
     load_mitigation_spec,
+    list_experiment_runs,
     main,
     naive_any_done,
+    persist_experiment_run,
     render_report,
     run_experiment,
     run_historical_benchmark,
@@ -141,6 +144,133 @@ class EvaluationHarnessTest(unittest.TestCase):
                 "| Confidence-only baseline | 50% | 100% | 12 |",
                 markdown_output.read_text(encoding="utf-8"),
             )
+
+    def test_sqlite_store_persists_complete_experiment_metadata(self) -> None:
+        result = run_historical_benchmark(
+            load_historical_benchmark(DEFAULT_CASE_PATH)
+        )
+        result["run_id"] = "RUN-STORE-001"
+        with tempfile.TemporaryDirectory() as temporary:
+            store = Path(temporary) / "runs.sqlite3"
+            record = persist_experiment_run(
+                store,
+                result,
+                suite="historical",
+                model="deterministic-reference",
+                prompt_version="hfb-v1",
+                git_commit="abc123",
+                latency_ms=12.5,
+                token_cost=0.0,
+                created_at_utc="2026-08-15T19:00:00Z",
+            )
+            self.assertEqual(record["run_id"], "RUN-STORE-001")
+            self.assertEqual(record["case_suite_version"], "HISTORICAL-FAILURE-BENCHMARK-v1")
+            self.assertEqual(record["treatment_accuracy"], 1.0)
+            listed = list_experiment_runs(store, 1)
+            self.assertEqual(listed, [record])
+            with sqlite3.connect(store) as connection:
+                version = connection.execute("PRAGMA user_version").fetchone()[0]
+                payload = connection.execute(
+                    "SELECT result_json FROM experiment_runs WHERE run_id = ?",
+                    ("RUN-STORE-001",),
+                ).fetchone()[0]
+            self.assertEqual(version, 1)
+            self.assertEqual(json.loads(payload)["fixture_count"], 24)
+
+    def test_sqlite_store_is_immutable_by_run_id(self) -> None:
+        result = run_historical_benchmark(
+            load_historical_benchmark(DEFAULT_CASE_PATH)
+        )
+        result["run_id"] = "RUN-DUPLICATE"
+        with tempfile.TemporaryDirectory() as temporary:
+            store = Path(temporary) / "runs.sqlite3"
+            kwargs = {
+                "suite": "historical",
+                "model": "deterministic-reference",
+                "prompt_version": "hfb-v1",
+                "git_commit": "abc123",
+                "latency_ms": 1.0,
+            }
+            persist_experiment_run(store, result, **kwargs)
+            with self.assertRaisesRegex(ValueError, "already exists"):
+                persist_experiment_run(store, result, **kwargs)
+            self.assertEqual(len(list_experiment_runs(store)), 1)
+
+    def test_sqlite_store_accepts_runtime_closure_suite(self) -> None:
+        result = run_experiment(load_case_suite(DEFAULT_CASE_PATH))
+        result["run_id"] = "RUN-CLOSURE-001"
+        with tempfile.TemporaryDirectory() as temporary:
+            store = Path(temporary) / "runs.sqlite3"
+            persist_experiment_run(
+                store,
+                result,
+                suite="closure",
+                model="companion-mind-closure-guard",
+                prompt_version="none",
+                git_commit="abc123",
+                latency_ms=2.0,
+            )
+            row = list_experiment_runs(store, 1)[0]
+            self.assertEqual(row["case_suite_version"], "EVAL-CASE-001")
+            self.assertEqual(row["baseline_accuracy"], 0.2)
+            self.assertEqual(row["treatment_accuracy"], 1.0)
+
+    def test_cli_persists_lists_and_emits_structured_logs(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            store = Path(temporary) / "runs.sqlite3"
+            report = Path(temporary) / "run.json"
+            listing = Path(temporary) / "runs.json"
+            error = io.StringIO()
+            with redirect_stderr(error):
+                exit_code = main(
+                    [
+                        "--suite",
+                        "historical",
+                        "--cases",
+                        str(DEFAULT_CASE_PATH),
+                        "--store",
+                        str(store),
+                        "--run-id",
+                        "RUN-CLI-001",
+                        "--model",
+                        "deterministic-reference",
+                        "--prompt-version",
+                        "hfb-v1",
+                        "--git-commit",
+                        "abc123",
+                        "--log-json",
+                        "--output",
+                        str(report),
+                    ]
+                )
+            self.assertEqual(exit_code, 0)
+            events = [json.loads(line)["event"] for line in error.getvalue().splitlines()]
+            self.assertEqual(events, ["run_started", "run_completed", "run_persisted"])
+            persisted = json.loads(report.read_text(encoding="utf-8"))
+            self.assertEqual(persisted["run_id"], "RUN-CLI-001")
+            self.assertEqual(persisted["experiment"]["git_commit"], "abc123")
+            self.assertEqual(
+                main(
+                    [
+                        "--store",
+                        str(store),
+                        "--list-runs",
+                        "1",
+                        "--output",
+                        str(listing),
+                    ]
+                ),
+                0,
+            )
+            rows = json.loads(listing.read_text(encoding="utf-8"))
+            self.assertEqual(rows[0]["run_id"], "RUN-CLI-001")
+
+    def test_cli_rejects_list_without_store(self) -> None:
+        error = io.StringIO()
+        with redirect_stderr(error):
+            exit_code = main(["--list-runs", "1"])
+        self.assertEqual(exit_code, 2)
+        self.assertIn("requires --store", error.getvalue())
 
     def test_mitigation_document_loads_and_matches_packaged_fallback(self) -> None:
         spec = load_mitigation_spec(DEFAULT_MITIGATION_PATH)


### PR DESCRIPTION
## Problem

The evaluation harness produced reproducible reports, but each execution disappeared after the process exited. There was no durable run identity, queryable experiment metadata, duplicate-run protection, or structured lifecycle log.

## What changed

- add a dependency-free SQLite experiment store with schema version 1;
- persist immutable run ID, suite version, model/policy, prompt version, git commit, UTC timestamp, latency, token cost, baseline/treatment accuracy, regression status, and canonical result JSON;
- reject duplicate `run_id` values instead of overwriting evidence;
- add `--store`, `--run-id`, `--model`, `--prompt-version`, `--git-commit`, `--token-cost`, and `--list-runs`;
- add JSON lifecycle events: `run_started`, `run_completed`, `run_persisted`, and `run_failed`;
- persist and query both the Closure Guard suite and Historical Failure Benchmark;
- exercise database creation, run insertion, metadata readback, and structured logs in CI;
- keep the repository at 15 tracked files and add no runtime dependency.

## How to reproduce

```bash
python -m pip install -e ../Companion-Mind
python -m pip install -e .
python -m unittest discover -s tests -v

llm-eval \
  --suite historical \
  --cases cases/anonymized/premature-parent-closure.md \
  --store /tmp/eval-runs.sqlite3 \
  --run-id DEMO-HFB-001 \
  --model deterministic-reference \
  --prompt-version hfb-v1 \
  --git-commit "$(git rev-parse HEAD)" \
  --log-json \
  --output /tmp/historical-run.json

llm-eval --store /tmp/eval-runs.sqlite3 --list-runs 10
```

## Measured result

- clean wheel install: PASS
- tests: 27/27 PASS
- SQLite schema version: 1
- inserted runs: 1/1
- metadata readback: exact
- structured events: 3/3 in order
- duplicate run overwrite attempts: rejected
- original Closure Guard regression: PASS
- Historical Failure Benchmark regression: PASS

## Privacy boundary

SQLite databases and JSON logs are runtime evidence and are ignored by git. The public repository contains no database snapshot, private prompt, credentials, account data, source archive location, or raw historical record.

## Known limitations

- SQLite is local single-node persistence, not PostgreSQL;
- no concurrent writer/load benchmark;
- no FastAPI surface yet;
- no Docker image yet;
- latency is local wall-clock measurement;
- token cost is caller-supplied metadata.

## Relationship to the core stack

This PR is the first Operationalization slice. It stacks on [Historical Failure Benchmark PR #4](https://github.com/aerenkolstein-code/llm-evaluation-lab/pull/4), which stacks on the executable integration in PR #3. Companion-Mind remains pinned as a read-only runtime dependency at `c6a2128271532746a5570b99ce0ccdea4618db4e`.

Next slices: read-only FastAPI query surface, then Docker reproducibility.
