### PR TITLE
Read-only experiment query API v0.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,3 +95,36 @@ jobs:
             --list-runs 1 \
             --output /tmp/experiment-runs.json
           python -c 'import json; rows=json.load(open("/tmp/experiment-runs.json")); assert len(rows)==1; assert rows[0]["regression_status"]=="PASS"; assert rows[0]["git_commit"]'
+
+      - name: Smoke-test read-only query API
+        working-directory: llm-evaluation-lab
+        run: |
+          llm-eval-api \
+            --store /tmp/eval-runs.sqlite3 \
+            --host 127.0.0.1 \
+            --port 8765 \
+            --log-level warning \
+            > /tmp/llm-eval-api.log 2>&1 &
+          API_PID=$!
+          trap 'kill "$API_PID" 2>/dev/null || true' EXIT
+          curl --silent --show-error --fail \
+            --retry 10 --retry-delay 1 --retry-connrefused \
+            http://127.0.0.1:8765/healthz \
+            > /tmp/api-health.json
+          curl --silent --show-error --fail \
+            'http://127.0.0.1:8765/v1/runs?limit=1' \
+            > /tmp/api-runs.json
+          python - <<'PY'
+          import json
+
+          health = json.load(open('/tmp/api-health.json', encoding='utf-8'))
+          runs = json.load(open('/tmp/api-runs.json', encoding='utf-8'))
+          assert health == {
+              'status': 'ok',
+              'service': 'llm-evaluation-lab',
+              'read_only': True,
+              'store_schema_version': 1,
+          }
+          assert len(runs) == 1
+          assert runs[0]['regression_status'] == 'PASS'
+          PY

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 | Baseline accuracy | 20% |
 | With Closure Guard | 100% |
 | Known regression failures caught | 4/4 |
-| Evaluation tests | 27/27 |
+| Evaluation tests | 32/32 |
 | Executable MitigationSpec | Runtime-validated |
 
 **Status:** Experimental / reproducible artifact  
@@ -111,6 +111,25 @@ Structured lifecycle events are emitted to `stderr`, leaving the JSON or
 Markdown report on `stdout` or in `--output`. SQLite files are runtime evidence
 and are ignored by git; they are not checked into the public repository.
 
+## Read-only query API v0.6
+
+An optional FastAPI surface exposes the immutable experiment store without
+adding any write route. It binds to loopback by default and opens SQLite with
+`mode=ro` plus `PRAGMA query_only=ON`.
+
+```bash
+llm-eval-api --store /tmp/eval-runs.sqlite3
+
+curl http://127.0.0.1:8000/healthz
+curl 'http://127.0.0.1:8000/v1/runs?limit=10'
+curl http://127.0.0.1:8000/v1/runs/RUN-ID
+```
+
+The list endpoint returns indexed metadata only. The detail endpoint returns one
+stored public-safe canonical result. There is no create, update or delete API,
+no authentication layer, and no claim that this local demonstration is ready for
+network or production exposure.
+
 ## Executable integration v0.3
 
 The experiment now owns a complete `mitigation-spec/v1` contract, validates it,
@@ -135,6 +154,7 @@ boundary explicit: Eval Lab specifies and verifies; Companion-Mind implements.
 - one uniform evidence-and-constraint gate with zero per-observation rules.
 - immutable SQLite experiment-run persistence and metadata query;
 - structured JSON lifecycle logging.
+- loopback-first read-only FastAPI health, list and detail endpoints.
 
 ### Measured in the current demonstration
 
@@ -146,9 +166,11 @@ boundary explicit: Eval Lab specifies and verifies; Companion-Mind implements.
 - historical benchmark baseline: **50%**;
 - uniform constraint gate: **100%**;
 - historical traps caught: **12/12**;
-- evaluation tests: **27/27**;
+- evaluation tests: **32/32**;
 - SQLite persistence and readback: **PASS**;
 - duplicate run protection: **PASS**.
+- API route write methods exposed: **0**;
+- read-only query mutation check: **PASS**.
 
 ### Not claimed
 
@@ -157,10 +179,11 @@ boundary explicit: Eval Lab specifies and verifies; Companion-Mind implements.
 - scientific benchmark validity;
 - enterprise-grade reliability;
 - live-LLM effectiveness or statistical significance.
+- authenticated or production-ready API deployment.
 
 ## Artifact map
 
-- `evaluation_lab.py` — loader, policies, grader, metrics, regression gate, and CLI
+- `evaluation_lab.py` — loader, policies, grader, metrics, regression gate, CLI, and read-only API
 - `cases/anonymized/premature-parent-closure.md` — first-loop case card plus executable 24-case historical benchmark
 - `experiments/closure-guard-mitigation.md` — mitigation, decision rule, and executable JSON contract
 - `results/EVAL-CASE-001.json` — checked deterministic result
@@ -169,8 +192,13 @@ boundary explicit: Eval Lab specifies and verifies; Companion-Mind implements.
 
 ## Roadmap
 
-**Operationalization** — SQLite experiment tracking and structured logging are implemented. Next: a read-only FastAPI query surface, followed by Docker reproducibility.
+**Operationalization** — SQLite experiment tracking, structured logging and a
+read-only FastAPI query surface are implemented. Next: Docker reproducibility.
 
 ## Privacy
 
 The fixtures preserve failure mechanisms without publishing the private scenes that revealed them. The historical suite uses synthetic neutral scenarios and excludes source quotations and archive locators. The repository contains no private Raw/L0 material, credentials, account data, client documents, personal records, or links to private archives.
+
+The API returns whatever canonical result was stored by the operator. Only
+public-safe runs belong in a publicly reachable deployment; this artifact binds
+to localhost by default and intentionally provides no authentication.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -29,7 +29,7 @@ companion-mind validate-mitigation --mitigation-spec /tmp/mitigation.json
 
 `llm-eval` 现在负责校验并输出完整的 `mitigation-spec/v1`，再用它实例化 Companion-Mind 的真实 `ClosureGuard`。报告同时记录 runtime 实际加载的 mitigation ID、safeguard ID、schema version 与 canonical SHA-256 fingerprint，从而证明“写入评测报告的配置”与“运行时真正执行的配置”一致。
 
-当前 **27/27 tests** 覆盖 Case/Spec 同步、非法规范、状态集合冲突、真实 runtime 回归、checked result、历史机制簇、最小对照、隐私定位符、双套 suite 的 SQLite 持久化、重复 run 防覆盖、结构化日志、双格式报告、CLI 原子输出与退出码契约。
+当前 **32/32 tests** 覆盖 Case/Spec 同步、非法规范、状态集合冲突、真实 runtime 回归、checked result、历史机制簇、最小对照、隐私定位符、双套 suite 的 SQLite 持久化、重复 run 防覆盖、结构化日志、只读 API、双格式报告、CLI 原子输出与退出码契约。
 
 ## Historical Failure Benchmark v0.4
 
@@ -41,10 +41,20 @@ llm-eval \
   --cases cases/anonymized/premature-parent-closure.md
 ```
 
-当前确定性基准：置信表面基线 **50%**，统一证据—约束门 **100%**，已抓住 **12/12** 个已知陷阱，逐观察规则数 **0**。全仓测试现为 **27/27**。这些数字只描述合成结构基准，不代表真实模型泛化、生产可靠性或科学 benchmark 有效性。
+当前确定性基准：置信表面基线 **50%**，统一证据—约束门 **100%**，已抓住 **12/12** 个已知陷阱，逐观察规则数 **0**。全仓测试现为 **32/32**。这些数字只描述合成结构基准，不代表真实模型泛化、生产可靠性或科学 benchmark 有效性。
 
 ## Persistent Experiment Tracking v0.5
 
 `llm-eval` 现在可以把每次运行原子写入 SQLite，记录 run ID、suite version、model/policy、prompt version、metrics、latency、token cost、git commit、UTC timestamp 与 canonical result JSON。`run_id` 不可变，重复写入会被拒绝；`--list-runs` 可回读元数据，`--log-json` 输出结构化生命周期日志。数据库属于运行证据，默认被 git 忽略，不进入公开仓库。
+
+## Read-Only FastAPI Query Surface v0.6
+
+`llm-eval-api --store /tmp/eval-runs.sqlite3` 提供三个只读端点：
+`/healthz`、`/v1/runs` 与 `/v1/runs/{run_id}`。SQLite 以 `mode=ro`
+和 `query_only` 打开；接口默认只监听 `127.0.0.1`，写方法数为 **0**，
+查询前后数据库哈希保持不变。
+
+该接口只适合本地、public-safe 实验记录查询。当前没有认证、授权、限流、
+公网部署或生产可靠性声明；操作方不得把私密提示词、档案定位符或账号信息写入实验元数据。
 
 第三仓仍保留 concept growth、prior lock-in、world-model drift、longitudinal evolution 与 experimental timeline；failure taxonomy 只是公开接口，不取代纵向评估内核。

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -37,3 +37,12 @@ Structured lifecycle logs use one JSON object per line and remain separate from
 the report channel: `run_started`, `run_completed`, `run_persisted`, or
 `run_failed`. This preserves machine-readable observability without changing the
 deterministic report contract when tracking is not requested.
+
+## Read-only query boundary
+
+The FastAPI surface is a projection over immutable SQLite evidence. It opens the
+database in URI `mode=ro`, enables SQLite `query_only`, and exposes only health,
+metadata-list, and single-run-detail GET routes. List responses omit the stored
+result payload; detail responses return the canonical result for one run. Tests
+hash the database before and after all three queries to prove the query path does
+not mutate the evidence file.

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -17,3 +17,9 @@ SQLite stores and JSON logs may contain experiment metadata and full public-safe
 result payloads. They are runtime evidence, not repository fixtures: database
 files are ignored by git, and operators must not pass private prompts, credentials
 or archive locations through model, prompt-version, git-commit or run-ID fields.
+
+The query API returns stored metadata and, for a requested run, its canonical
+result payload. It therefore defaults to loopback and ships without any write
+route. This is not an authentication boundary: operators must not expose it to a
+network or populate it with non-public evidence without adding deployment-specific
+access controls outside this artifact.

--- a/evaluation_lab.py
+++ b/evaluation_lab.py
@@ -14,10 +14,10 @@ import uuid
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Callable, Iterable, Mapping, Sequence
+from typing import Any, Callable, Iterable, Mapping, Sequence
 
 
-__version__ = "0.5.0"
+__version__ = "0.6.0"
 
 Child = Mapping[str, str]
 Case = Mapping[str, object]
@@ -945,6 +945,34 @@ def _initialize_store(connection: sqlite3.Connection) -> None:
         connection.execute(f"PRAGMA user_version = {STORE_SCHEMA_VERSION}")
 
 
+def _open_read_only_store(store_path: str | Path) -> sqlite3.Connection:
+    """Open an initialized experiment store without permitting writes."""
+
+    path = Path(store_path)
+    if not path.is_file():
+        raise ValueError(f"experiment store does not exist: {path}")
+    try:
+        connection = sqlite3.connect(f"{path.resolve().as_uri()}?mode=ro", uri=True)
+        connection.execute("PRAGMA query_only = ON")
+        version = int(connection.execute("PRAGMA user_version").fetchone()[0])
+        if version != STORE_SCHEMA_VERSION:
+            connection.close()
+            raise ValueError(
+                f"unsupported experiment store schema version {version}"
+            )
+        table = connection.execute(
+            "SELECT name FROM sqlite_master "
+            "WHERE type = 'table' AND name = 'experiment_runs'"
+        ).fetchone()
+        if table is None:
+            connection.close()
+            raise ValueError("experiment store is missing experiment_runs")
+        connection.row_factory = sqlite3.Row
+        return connection
+    except sqlite3.DatabaseError as exc:
+        raise ValueError(f"experiment store error: {exc}") from exc
+
+
 def persist_experiment_run(
     store_path: str | Path,
     result: Mapping[str, object],
@@ -1052,13 +1080,8 @@ def list_experiment_runs(
 
     if limit < 1 or limit > 1000:
         raise ValueError("run list limit must be between 1 and 1000")
-    path = Path(store_path)
-    if not path.exists():
-        raise ValueError(f"experiment store does not exist: {path}")
     try:
-        with sqlite3.connect(path) as connection:
-            _initialize_store(connection)
-            connection.row_factory = sqlite3.Row
+        with _open_read_only_store(store_path) as connection:
             rows = connection.execute(
                 """
                 SELECT run_id, suite, case_suite_version, model,
@@ -1074,6 +1097,134 @@ def list_experiment_runs(
     except sqlite3.DatabaseError as exc:
         raise ValueError(f"experiment store error: {exc}") from exc
     return [dict(row) for row in rows]
+
+
+def get_experiment_run(
+    store_path: str | Path, run_id: str
+) -> dict[str, object] | None:
+    """Return one immutable experiment record and its canonical result."""
+
+    normalized_run_id = run_id.strip()
+    if not normalized_run_id:
+        raise ValueError("run_id must be a non-empty string")
+    try:
+        with _open_read_only_store(store_path) as connection:
+            row = connection.execute(
+                """
+                SELECT run_id, suite, case_suite_version, model,
+                       prompt_version, git_commit, created_at_utc,
+                       latency_ms, token_cost, baseline_accuracy,
+                       treatment_accuracy, regression_status, result_json
+                FROM experiment_runs
+                WHERE run_id = ?
+                """,
+                (normalized_run_id,),
+            ).fetchone()
+    except sqlite3.DatabaseError as exc:
+        raise ValueError(f"experiment store error: {exc}") from exc
+    if row is None:
+        return None
+    record = dict(row)
+    result_json = record.pop("result_json")
+    record["result"] = json.loads(str(result_json))
+    return record
+
+
+def create_app(store_path: str | Path) -> Any:
+    """Create a local-first, read-only FastAPI query surface."""
+
+    try:
+        from fastapi import FastAPI, HTTPException, Query
+    except ModuleNotFoundError as exc:
+        raise RuntimeError(
+            "Install the API dependencies: python -m pip install -e ."
+        ) from exc
+
+    store = Path(store_path).resolve()
+    with _open_read_only_store(store):
+        pass
+
+    app = FastAPI(
+        title="LLM Evaluation Lab Query API",
+        description=(
+            "Read-only access to immutable, public-safe experiment records. "
+            "No write routes are exposed."
+        ),
+        version=__version__,
+        docs_url=None,
+        redoc_url=None,
+    )
+
+    @app.get("/healthz", tags=["service"])
+    def healthz() -> dict[str, object]:
+        try:
+            with _open_read_only_store(store):
+                pass
+        except ValueError as exc:
+            raise HTTPException(status_code=503, detail=str(exc)) from exc
+        return {
+            "status": "ok",
+            "service": "llm-evaluation-lab",
+            "read_only": True,
+            "store_schema_version": STORE_SCHEMA_VERSION,
+        }
+
+    @app.get("/v1/runs", tags=["experiments"])
+    def runs(
+        limit: int = Query(default=20, ge=1, le=1000),
+    ) -> list[dict[str, object]]:
+        try:
+            return list_experiment_runs(store, limit)
+        except ValueError as exc:
+            raise HTTPException(status_code=503, detail=str(exc)) from exc
+
+    @app.get("/v1/runs/{run_id}", tags=["experiments"])
+    def run_detail(run_id: str) -> dict[str, object]:
+        try:
+            record = get_experiment_run(store, run_id)
+        except ValueError as exc:
+            raise HTTPException(status_code=503, detail=str(exc)) from exc
+        if record is None:
+            raise HTTPException(status_code=404, detail="experiment run not found")
+        return record
+
+    return app
+
+
+def serve_main(argv: Sequence[str] | None = None) -> int:
+    """Serve the read-only API on loopback by default."""
+
+    parser = argparse.ArgumentParser(
+        prog="llm-eval-api",
+        description="Serve a read-only FastAPI view of an experiment store.",
+    )
+    parser.add_argument("--store", type=Path, required=True)
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=8000)
+    parser.add_argument(
+        "--allow-network",
+        action="store_true",
+        help="allow binding beyond localhost; no authentication is provided",
+    )
+    parser.add_argument("--log-level", default="info")
+    args = parser.parse_args(argv)
+    if args.host not in {"127.0.0.1", "localhost", "::1"} and not args.allow_network:
+        parser.error("non-loopback --host requires --allow-network")
+    if not 1 <= args.port <= 65535:
+        parser.error("--port must be between 1 and 65535")
+    try:
+        import uvicorn
+    except ModuleNotFoundError as exc:
+        raise RuntimeError(
+            "Install the API dependencies: python -m pip install -e ."
+        ) from exc
+    uvicorn.run(
+        create_app(args.store),
+        host=args.host,
+        port=args.port,
+        log_level=args.log_level,
+    )
+    return 0
 
 
 def emit_json_log(enabled: bool, event: str, **fields: object) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,13 +4,17 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-evaluation-lab"
-version = "0.5.0"
-description = "Public-safe LLM evaluation harness with persistent experiment tracking"
+version = "0.6.0"
+description = "Public-safe LLM evaluation harness with persistent experiment tracking and a read-only API"
 requires-python = ">=3.11"
-dependencies = []
+dependencies = [
+  "fastapi>=0.115,<1",
+  "uvicorn>=0.30,<1",
+]
 
 [project.scripts]
 llm-eval = "evaluation_lab:main"
+llm-eval-api = "evaluation_lab:serve_main"
 
 [tool.setuptools]
 py-modules = ["evaluation_lab"]

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -1,3 +1,5 @@
+import asyncio
+import hashlib
 import json
 import io
 import sqlite3
@@ -6,6 +8,13 @@ import unittest
 from contextlib import redirect_stderr
 from pathlib import Path
 from unittest.mock import patch
+
+try:
+    import fastapi  # noqa: F401
+except ModuleNotFoundError:
+    HAS_FASTAPI = False
+else:
+    HAS_FASTAPI = True
 
 from evaluation_lab import (
     BUILTIN_MITIGATION_SPEC,
@@ -16,8 +25,10 @@ from evaluation_lab import (
     closure_guard_policy,
     confidence_only_baseline,
     constraint_gate_policy,
+    create_app,
     evaluate_historical_policy,
     evaluate_policy,
+    get_experiment_run,
     load_case_suite,
     load_historical_benchmark,
     load_mitigation_spec,
@@ -34,6 +45,51 @@ from evaluation_lab import (
 
 ROOT = Path(__file__).resolve().parents[1]
 CHECKED_RESULT = ROOT / "results" / "EVAL-CASE-001.json"
+
+
+def asgi_get(
+    app: object, path: str, query_string: bytes = b""
+) -> tuple[int, dict[str, object]]:
+    """Exercise one GET request without adding an HTTP test dependency."""
+
+    async def invoke() -> tuple[int, dict[str, object]]:
+        messages: list[dict[str, object]] = []
+        request_sent = False
+
+        async def receive() -> dict[str, object]:
+            nonlocal request_sent
+            if request_sent:
+                return {"type": "http.disconnect"}
+            request_sent = True
+            return {"type": "http.request", "body": b"", "more_body": False}
+
+        async def send(message: dict[str, object]) -> None:
+            messages.append(message)
+
+        scope = {
+            "type": "http",
+            "asgi": {"version": "3.0"},
+            "http_version": "1.1",
+            "method": "GET",
+            "scheme": "http",
+            "path": path,
+            "raw_path": path.encode("utf-8"),
+            "query_string": query_string,
+            "headers": [(b"host", b"testserver")],
+            "client": ("127.0.0.1", 12345),
+            "server": ("127.0.0.1", 8000),
+            "root_path": "",
+        }
+        await app(scope, receive, send)  # type: ignore[operator]
+        start = next(item for item in messages if item["type"] == "http.response.start")
+        body = b"".join(
+            item.get("body", b"")  # type: ignore[arg-type]
+            for item in messages
+            if item["type"] == "http.response.body"
+        )
+        return int(start["status"]), json.loads(body)
+
+    return asyncio.run(invoke())
 
 
 class EvaluationHarnessTest(unittest.TestCase):
@@ -214,6 +270,88 @@ class EvaluationHarnessTest(unittest.TestCase):
             self.assertEqual(row["case_suite_version"], "EVAL-CASE-001")
             self.assertEqual(row["baseline_accuracy"], 0.2)
             self.assertEqual(row["treatment_accuracy"], 1.0)
+
+    def _seed_api_store(self, store: Path, run_id: str = "RUN-API-001") -> None:
+        result = run_historical_benchmark(
+            load_historical_benchmark(DEFAULT_CASE_PATH)
+        )
+        result["run_id"] = run_id
+        persist_experiment_run(
+            store,
+            result,
+            suite="historical",
+            model="deterministic-reference",
+            prompt_version="hfb-v1",
+            git_commit="abc123",
+            latency_ms=3.5,
+            created_at_utc="2026-08-15T20:00:00Z",
+        )
+
+    @unittest.skipUnless(HAS_FASTAPI, "FastAPI is not installed")
+    def test_api_exposes_only_read_routes(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            store = Path(temporary) / "runs.sqlite3"
+            self._seed_api_store(store)
+            app = create_app(store)
+            methods = {
+                method
+                for route in app.routes
+                for method in (getattr(route, "methods", None) or set())
+            }
+            self.assertTrue(methods)
+            self.assertEqual(methods - {"GET", "HEAD"}, set())
+
+    @unittest.skipUnless(HAS_FASTAPI, "FastAPI is not installed")
+    def test_api_health_reports_read_only_schema(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            store = Path(temporary) / "runs.sqlite3"
+            self._seed_api_store(store)
+            status, body = asgi_get(create_app(store), "/healthz")
+            self.assertEqual(status, 200)
+            self.assertEqual(body["status"], "ok")
+            self.assertTrue(body["read_only"])
+            self.assertEqual(body["store_schema_version"], 1)
+
+    @unittest.skipUnless(HAS_FASTAPI, "FastAPI is not installed")
+    def test_api_lists_metadata_and_returns_canonical_detail(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            store = Path(temporary) / "runs.sqlite3"
+            self._seed_api_store(store)
+            app = create_app(store)
+            list_status, rows = asgi_get(app, "/v1/runs", b"limit=1")
+            self.assertEqual(list_status, 200)
+            self.assertEqual(len(rows), 1)
+            self.assertEqual(rows[0]["run_id"], "RUN-API-001")
+            self.assertNotIn("result", rows[0])
+            detail_status, detail = asgi_get(app, "/v1/runs/RUN-API-001")
+            self.assertEqual(detail_status, 200)
+            self.assertEqual(detail["run_id"], "RUN-API-001")
+            self.assertEqual(detail["result"]["fixture_count"], 24)
+            self.assertEqual(
+                get_experiment_run(store, "RUN-API-001"), detail
+            )
+
+    @unittest.skipUnless(HAS_FASTAPI, "FastAPI is not installed")
+    def test_api_returns_404_for_unknown_run(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            store = Path(temporary) / "runs.sqlite3"
+            self._seed_api_store(store)
+            status, body = asgi_get(create_app(store), "/v1/runs/UNKNOWN")
+            self.assertEqual(status, 404)
+            self.assertEqual(body["detail"], "experiment run not found")
+
+    @unittest.skipUnless(HAS_FASTAPI, "FastAPI is not installed")
+    def test_api_queries_do_not_mutate_the_sqlite_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            store = Path(temporary) / "runs.sqlite3"
+            self._seed_api_store(store)
+            before = hashlib.sha256(store.read_bytes()).hexdigest()
+            app = create_app(store)
+            asgi_get(app, "/healthz")
+            asgi_get(app, "/v1/runs", b"limit=1")
+            asgi_get(app, "/v1/runs/RUN-API-001")
+            after = hashlib.sha256(store.read_bytes()).hexdigest()
+            self.assertEqual(after, before)
 
     def test_cli_persists_lists_and_emits_structured_logs(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:


### PR DESCRIPTION
## Problem

Persistent experiment runs were queryable only through the CLI. Reviewers could not inspect health, indexed run metadata, or one canonical run result through a standard service boundary.

## What changed

- add an optional FastAPI application over the existing SQLite experiment store;
- expose only `GET /healthz`, `GET /v1/runs`, and `GET /v1/runs/{run_id}`;
- open SQLite with URI `mode=ro` and `PRAGMA query_only=ON`;
- keep list responses metadata-only while returning one canonical public-safe result from the detail endpoint;
- bind the server to `127.0.0.1` by default and require an explicit flag for non-loopback binding;
- add the `llm-eval-api` console command;
- add ASGI route, response, 404, and database non-mutation tests;
- add a real HTTP smoke test to GitHub Actions;
- keep the repository at 15 tracked files.

## How to reproduce

```bash
python -m pip install -e ../Companion-Mind
python -m pip install -e .
python -m unittest discover -s tests -v

llm-eval \
  --suite historical \
  --cases cases/anonymized/premature-parent-closure.md \
  --store /tmp/eval-runs.sqlite3 \
  --run-id API-DEMO-001 \
  --git-commit "$(git rev-parse HEAD)" \
  --output /tmp/api-demo.json

llm-eval-api --store /tmp/eval-runs.sqlite3

curl http://127.0.0.1:8000/healthz
curl 'http://127.0.0.1:8000/v1/runs?limit=10'
curl http://127.0.0.1:8000/v1/runs/API-DEMO-001
```

## Measured result

- local test discovery: 32 tests;
- existing dependency-free/core tests: 27/27 PASS;
- local FastAPI integration tests: 5 explicitly skipped because this execution environment blocked dependency download;
- SQLite read-only detail readback: PASS;
- tracked files: 15;
- GitHub Actions clean install: PASS;
- complete test suite: 32/32 PASS;
- real HTTP health/list smoke test: PASS.

## Tests

GitHub Actions performs a clean install, runs the complete suite, creates a real SQLite experiment record, starts `llm-eval-api`, queries the health and list endpoints over HTTP, and validates their JSON responses.

## Privacy boundary

The API is a view over operator-supplied experiment evidence. It has no write route, defaults to loopback, and does not add any database snapshot, private prompt, credential, archive locator, account data, or source record to the repository.

## Known limitations

- no authentication, authorization, rate limiting, TLS, or production deployment;
- non-loopback exposure is unsafe without deployment-specific controls;
- SQLite remains local single-node storage;
- no pagination cursor or concurrent-load benchmark;
- no Docker image yet.

## Relationship to the core stack

This PR stacks on [Persistent Experiment Tracking PR #5](https://github.com/aerenkolstein-code/llm-evaluation-lab/pull/5), which supplies the immutable SQLite evidence queried here. PR #5 stacks on [Historical Failure Benchmark PR #4](https://github.com/aerenkolstein-code/llm-evaluation-lab/pull/4). Companion-Mind remains the read-only safeguard runtime dependency.

Next slice: Docker reproducibility.