### PR TITLE
Docker reproducibility v0.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -128,3 +128,53 @@ jobs:
           assert len(runs) == 1
           assert runs[0]['regression_status'] == 'PASS'
           PY
+
+      - name: Build and smoke-test Docker image
+        run: |
+          docker build \
+            --tag llm-evaluation-lab:ci \
+            --build-arg COMPANION_MIND_COMMIT=c6a2128271532746a5570b99ce0ccdea4618db4e \
+            llm-evaluation-lab
+
+          docker run --rm llm-evaluation-lab:ci --version \
+            > /tmp/docker-version.txt
+          grep --quiet '^llm-eval 0.7.0$' /tmp/docker-version.txt
+
+          docker run --rm llm-evaluation-lab:ci \
+            --suite historical \
+            --cases cases/anonymized/premature-parent-closure.md \
+            > /tmp/docker-historical.json
+          python -c 'import json; result=json.load(open("/tmp/docker-historical.json")); assert result["regression"]["status"]=="PASS"; assert result["fixture_count"]==24'
+
+          mkdir -p /tmp/llm-eval-docker-data
+          chmod 0777 /tmp/llm-eval-docker-data
+          docker run --rm \
+            --volume /tmp/llm-eval-docker-data:/data \
+            llm-evaluation-lab:ci \
+            --suite historical \
+            --cases cases/anonymized/premature-parent-closure.md \
+            --store /data/eval-runs.sqlite3 \
+            --run-id CONTAINER-HFB-001 \
+            --git-commit "$EVAL_GIT_COMMIT" \
+            --output /data/container-run.json
+
+          trap 'docker rm --force llm-eval-api-ci 2>/dev/null || true' EXIT
+          docker run --rm --detach \
+            --name llm-eval-api-ci \
+            --publish 127.0.0.1:8766:8000 \
+            --volume /tmp/llm-eval-docker-data:/data:ro \
+            --entrypoint llm-eval-api \
+            llm-evaluation-lab:ci \
+            --store /data/eval-runs.sqlite3 \
+            --host 0.0.0.0 \
+            --allow-network \
+            --port 8000 \
+            --log-level warning
+          curl --silent --show-error --fail \
+            --retry 10 --retry-delay 1 --retry-connrefused \
+            http://127.0.0.1:8766/healthz \
+            > /tmp/docker-api-health.json
+          curl --silent --show-error --fail \
+            'http://127.0.0.1:8766/v1/runs?limit=1' \
+            > /tmp/docker-api-runs.json
+          python -c 'import json; health=json.load(open("/tmp/docker-api-health.json")); runs=json.load(open("/tmp/docker-api-runs.json")); assert health["read_only"] is True; assert runs[0]["run_id"]=="CONTAINER-HFB-001"'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -170,10 +170,20 @@ jobs:
             --allow-network \
             --port 8000 \
             --log-level warning
-          curl --silent --show-error --fail \
-            --retry 10 --retry-delay 1 --retry-connrefused \
-            http://127.0.0.1:8766/healthz \
-            > /tmp/docker-api-health.json
+          API_READY=false
+          for attempt in $(seq 1 20); do
+            if curl --silent --show-error --fail \
+              http://127.0.0.1:8766/healthz \
+              > /tmp/docker-api-health.json; then
+              API_READY=true
+              break
+            fi
+            sleep 1
+          done
+          if [ "$API_READY" != true ]; then
+            docker logs llm-eval-api-ci
+            exit 1
+          fi
           curl --silent --show-error --fail \
             'http://127.0.0.1:8766/v1/runs?limit=1' \
             > /tmp/docker-api-runs.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+FROM python:3.11-slim-bookworm
+
+ARG COMPANION_MIND_COMMIT=c6a2128271532746a5570b99ce0ccdea4618db4e
+
+LABEL org.opencontainers.image.source="https://github.com/aerenkolstein-code/llm-evaluation-lab" \
+      org.opencontainers.image.description="Reproducible public-safe LLM evaluation harness" \
+      org.opencontainers.image.version="0.7.0"
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1
+
+WORKDIR /opt/llm-evaluation-lab
+
+COPY pyproject.toml evaluation_lab.py ./
+COPY cases ./cases
+COPY experiments ./experiments
+COPY results ./results
+COPY schemas ./schemas
+
+RUN python -m pip install --no-cache-dir \
+      "https://github.com/aerenkolstein-code/Companion-Mind/archive/${COMPANION_MIND_COMMIT}.tar.gz" \
+    && python -m pip install --no-cache-dir -e . \
+    && python -m compileall -q evaluation_lab.py \
+    && useradd --create-home --uid 10001 appuser \
+    && chown -R appuser:appuser /opt/llm-evaluation-lab
+
+USER 10001:10001
+
+EXPOSE 8000
+
+ENTRYPOINT ["llm-eval"]
+CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 | With Closure Guard | 100% |
 | Known regression failures caught | 4/4 |
 | Evaluation tests | 32/32 |
+| Container CLI/API smoke | PASS |
 | Executable MitigationSpec | Runtime-validated |
 
 **Status:** Experimental / reproducible artifact  
@@ -130,6 +131,39 @@ stored public-safe canonical result. There is no create, update or delete API,
 no authentication layer, and no claim that this local demonstration is ready for
 network or production exposure.
 
+## Docker reproducibility v0.7
+
+The repository includes one minimal Dockerfile. It pins the Companion-Mind runtime
+to commit `c6a2128271532746a5570b99ce0ccdea4618db4e`, installs the evaluation
+package, and runs as an unprivileged user.
+
+```bash
+docker build -t llm-evaluation-lab:0.7 .
+
+docker run --rm llm-evaluation-lab:0.7 \
+  --suite historical \
+  --cases cases/anonymized/premature-parent-closure.md
+```
+
+To query a previously created store, mount it read-only and publish only to host
+loopback:
+
+```bash
+docker run --rm \
+  -p 127.0.0.1:8000:8000 \
+  -v /absolute/path/to/data:/data:ro \
+  --entrypoint llm-eval-api \
+  llm-evaluation-lab:0.7 \
+  --store /data/eval-runs.sqlite3 \
+  --host 0.0.0.0 \
+  --allow-network
+```
+
+CI builds the image from a clean checkout, verifies version `0.7.0`, executes the
+24-case historical regression, creates a mounted SQLite record, then queries the
+containerized API over HTTP. This is reproducible local packaging, not a published
+registry image or production deployment.
+
 ## Executable integration v0.3
 
 The experiment now owns a complete `mitigation-spec/v1` contract, validates it,
@@ -155,6 +189,7 @@ boundary explicit: Eval Lab specifies and verifies; Companion-Mind implements.
 - immutable SQLite experiment-run persistence and metadata query;
 - structured JSON lifecycle logging.
 - loopback-first read-only FastAPI health, list and detail endpoints.
+- non-root Docker packaging with pinned Companion-Mind runtime commit.
 
 ### Measured in the current demonstration
 
@@ -171,6 +206,8 @@ boundary explicit: Eval Lab specifies and verifies; Companion-Mind implements.
 - duplicate run protection: **PASS**.
 - API route write methods exposed: **0**;
 - read-only query mutation check: **PASS**.
+- Docker image build: **PASS**;
+- containerized CLI/API smoke: **PASS**.
 
 ### Not claimed
 
@@ -180,6 +217,7 @@ boundary explicit: Eval Lab specifies and verifies; Companion-Mind implements.
 - enterprise-grade reliability;
 - live-LLM effectiveness or statistical significance.
 - authenticated or production-ready API deployment.
+- bit-for-bit dependency or base-image reproducibility.
 
 ## Artifact map
 
@@ -189,11 +227,13 @@ boundary explicit: Eval Lab specifies and verifies; Companion-Mind implements.
 - `results/EVAL-CASE-001.json` — checked deterministic result
 - `tests/test_evaluation.py` — loader, reproducibility, reporting, and regression assertions
 - `schemas/` — shared evaluation and mitigation contracts
+- `Dockerfile` — non-root container build for CLI and read-only API reproduction
 
 ## Roadmap
 
-**Operationalization** — SQLite experiment tracking, structured logging and a
-read-only FastAPI query surface are implemented. Next: Docker reproducibility.
+**Operationalization baseline complete** — SQLite experiment tracking, structured
+logging, a read-only FastAPI query surface, and Docker CLI/API reproduction are
+implemented. Further infrastructure expansion requires a separate scope decision.
 
 ## Privacy
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -57,4 +57,20 @@ llm-eval \
 该接口只适合本地、public-safe 实验记录查询。当前没有认证、授权、限流、
 公网部署或生产可靠性声明；操作方不得把私密提示词、档案定位符或账号信息写入实验元数据。
 
+## Docker Reproducibility v0.7
+
+仓库新增唯一一个受控文件 `Dockerfile`，将 Companion-Mind runtime 固定在
+`c6a2128271532746a5570b99ce0ccdea4618db4e`，容器以非 root 用户运行。
+
+```bash
+docker build -t llm-evaluation-lab:0.7 .
+docker run --rm llm-evaluation-lab:0.7 \
+  --suite historical \
+  --cases cases/anonymized/premature-parent-closure.md
+```
+
+GitHub Actions 会从 clean checkout 构建镜像、核验 `0.7.0`、复跑 24 案例历史基准、
+在挂载目录中生成 SQLite 记录，并通过真实 HTTP 查询容器化 API。它证明本地容器复跑能力，
+不代表已经发布 registry image、完成云部署或达到生产可靠性。
+
 第三仓仍保留 concept growth、prior lock-in、world-model drift、longitudinal evolution 与 experimental timeline；failure taxonomy 只是公开接口，不取代纵向评估内核。

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -46,3 +46,15 @@ metadata-list, and single-run-detail GET routes. List responses omit the stored
 result payload; detail responses return the canonical result for one run. Tests
 hash the database before and after all three queries to prove the query path does
 not mutate the evidence file.
+
+## Container reproduction
+
+The Docker image fixes the Companion-Mind runtime to an explicit commit, copies
+only the executable public-safe fixture and schema directories, installs the lab
+in editable mode so checked fixtures remain addressable, and drops privileges to
+UID 10001. CI treats the image as a black box: it verifies the version, executes
+the historical regression, writes one SQLite run through a mounted directory,
+then starts the API with that directory mounted read-only and queries it over HTTP.
+
+The Python base tag and transitive package resolution are not locked by digest;
+this is repeatable functional packaging, not bit-for-bit image reproducibility.

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -23,3 +23,9 @@ result payload. It therefore defaults to loopback and ships without any write
 route. This is not an authentication boundary: operators must not expose it to a
 network or populate it with non-public evidence without adding deployment-specific
 access controls outside this artifact.
+
+The image contains only repository public-safe files and a pinned public
+Companion-Mind runtime commit. No database, log, credential, environment file or
+private archive path is copied into the image. Runtime evidence must enter through
+an explicit volume; read-only API use should mount that volume with `:ro` and bind
+the published host port to loopback.

--- a/evaluation_lab.py
+++ b/evaluation_lab.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from typing import Any, Callable, Iterable, Mapping, Sequence
 
 
-__version__ = "0.6.0"
+__version__ = "0.7.0"
 
 Child = Mapping[str, str]
 Case = Mapping[str, object]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-evaluation-lab"
-version = "0.6.0"
-description = "Public-safe LLM evaluation harness with persistent experiment tracking and a read-only API"
+version = "0.7.0"
+description = "Container-reproducible LLM evaluation harness with experiment tracking and a read-only API"
 requires-python = ">=3.11"
 dependencies = [
   "fastapi>=0.115,<1",


### PR DESCRIPTION
## Problem

The CLI, SQLite experiment store, and read-only API were reproducible only after a reviewer manually assembled a Python environment and installed the sibling runtime. There was no clean container boundary proving that the complete public-safe stack could run together.

## What changed

- add one minimal `Dockerfile` as the only new repository file;
- use `python:3.11-slim-bookworm`;
- pin Companion-Mind to commit `c6a2128271532746a5570b99ce0ccdea4618db4e`;
- copy only the executable public-safe cases, experiments, results, and schemas;
- install the evaluation package and expose the existing `llm-eval` entrypoint;
- drop privileges to UID 10001;
- document CLI and read-only API container reproduction;
- extend CI to build the image, verify version 0.7.0, execute the 24-case regression, create a mounted SQLite record, and query the containerized API over HTTP.

## How to reproduce

```bash
docker build -t llm-evaluation-lab:0.7 .

docker run --rm llm-evaluation-lab:0.7 \
  --suite historical \
  --cases cases/anonymized/premature-parent-closure.md
```

For a read-only API over an existing store:

```bash
docker run --rm \
  -p 127.0.0.1:8000:8000 \
  -v /absolute/path/to/data:/data:ro \
  --entrypoint llm-eval-api \
  llm-evaluation-lab:0.7 \
  --store /data/eval-runs.sqlite3 \
  --host 0.0.0.0 \
  --allow-network
```

## Measured result

- complete Python test suite: 32/32 PASS;
- clean Docker image build: PASS;
- container version / 24-case regression / mounted SQLite record / API HTTP smoke: PASS;
- Dockerfile privacy-boundary review: PASS;
- tracked files: 16 (one controlled Dockerfile addition).

The first Actions attempt exposed an API-startup readiness race after the image, CLI, benchmark, and database checks had already passed. A workflow-only bounded readiness loop fixed the race; the second clean run passed end to end.

## Tests

GitHub Actions run [#20](https://github.com/aerenkolstein-code/llm-evaluation-lab/actions/runs/31907211406) completed successfully. Job `95066799491` ran all 32 Python tests, built the image from a clean checkout, verified `llm-eval 0.7.0`, executed the Historical Failure Benchmark, wrote immutable run `CONTAINER-HFB-001` through a mounted volume, launched `llm-eval-api` with that volume read-only, and validated health/list responses over HTTP.

## Privacy boundary

The image copies no database, log, credential, environment file, private prompt, archive locator, or raw historical material. Runtime evidence enters only through an explicit volume. The API example mounts that volume read-only and publishes only to host loopback.

## Known limitations

- no published registry image or SBOM;
- Python base image is tag-pinned, not digest-pinned;
- transitive dependencies are not bit-for-bit locked;
- no multi-architecture build;
- no Compose, Kubernetes, cloud deployment, authentication, or production-readiness claim.

## Relationship to the core stack

This PR stacks on [Read-only Experiment Query API PR #6](https://github.com/aerenkolstein-code/llm-evaluation-lab/pull/6), which stacks on [Persistent Experiment Tracking PR #5](https://github.com/aerenkolstein-code/llm-evaluation-lab/pull/5). The container packages the existing evaluation and runtime boundary; it does not change benchmark semantics.

This closes the planned Operationalization baseline.