### PR TITLE
ENG-SC-01 P0: add SEARCH-CUP-02 offline fairness harness

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,24 @@ jobs:
         working-directory: llm-evaluation-lab
         run: python -m unittest discover -s tests -v
 
+      - name: Run SEARCH-CUP-02 P0 offline gate
+        working-directory: llm-evaluation-lab
+        run: |
+          llm-search-cup preflight > /tmp/search-cup-preflight.json
+          llm-search-cup demo --format json --output /tmp/search-cup-offline.json
+          python - <<'PY'
+          import json
+
+          preflight = json.load(open('/tmp/search-cup-preflight.json', encoding='utf-8'))
+          report = json.load(open('/tmp/search-cup-offline.json', encoding='utf-8'))
+          assert preflight['mode'] == 'OFFLINE_ONLY'
+          assert preflight['official_match_authorized'] is False
+          assert preflight['live_provider_adapters'] == 0
+          assert preflight['entrant_count'] == 4
+          assert len(report['scores']) == 4
+          assert all(score['exact_model_id'].startswith('fake-') for score in report['scores'])
+          PY
+
       - name: Run checked experiment
         working-directory: llm-evaluation-lab
         run: |
@@ -138,7 +156,14 @@ jobs:
 
           docker run --rm llm-evaluation-lab:ci --version \
             > /tmp/docker-version.txt
-          grep --quiet '^llm-eval 0.7.0$' /tmp/docker-version.txt
+          grep --quiet '^llm-eval 0.8.0$' /tmp/docker-version.txt
+
+          docker run --rm \
+            --entrypoint llm-search-cup \
+            llm-evaluation-lab:ci \
+            preflight \
+            > /tmp/docker-search-cup-preflight.json
+          python -c 'import json; result=json.load(open("/tmp/docker-search-cup-preflight.json")); assert result["mode"]=="OFFLINE_ONLY"; assert result["official_match_authorized"] is False'
 
           docker run --rm llm-evaluation-lab:ci \
             --suite historical \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG COMPANION_MIND_COMMIT=c6a2128271532746a5570b99ce0ccdea4618db4e
 
 LABEL org.opencontainers.image.source="https://github.com/aerenkolstein-code/llm-evaluation-lab" \
       org.opencontainers.image.description="Reproducible public-safe LLM evaluation harness" \
-      org.opencontainers.image.version="0.7.0"
+      org.opencontainers.image.version="0.8.0"
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
@@ -13,6 +13,9 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 WORKDIR /opt/llm-evaluation-lab
 
 COPY pyproject.toml evaluation_lab.py ./
+COPY search_cup ./search_cup
+COPY candidates ./candidates
+COPY competitions ./competitions
 COPY cases ./cases
 COPY experiments ./experiments
 COPY results ./results
@@ -21,7 +24,7 @@ COPY schemas ./schemas
 RUN python -m pip install --no-cache-dir \
       "https://github.com/aerenkolstein-code/Companion-Mind/archive/${COMPANION_MIND_COMMIT}.tar.gz" \
     && python -m pip install --no-cache-dir -e . \
-    && python -m compileall -q evaluation_lab.py \
+    && python -m compileall -q evaluation_lab.py search_cup \
     && useradd --create-home --uid 10001 appuser \
     && chown -R appuser:appuser /opt/llm-evaluation-lab
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@
 | Evaluation tests | 32/32 |
 | Container CLI/API smoke | PASS |
 | Executable MitigationSpec | Runtime-validated |
+| SEARCH-CUP-02 P0 offline tests | 21/21 |
+| Full repository tests | 53/53 |
 
 **Status:** Experimental / reproducible artifact  
 **Evidence level:** E3 — reproducible public-safe evaluation
@@ -131,16 +133,16 @@ stored public-safe canonical result. There is no create, update or delete API,
 no authentication layer, and no claim that this local demonstration is ready for
 network or production exposure.
 
-## Docker reproducibility v0.7
+## Docker reproducibility (introduced in v0.7)
 
 The repository includes one minimal Dockerfile. It pins the Companion-Mind runtime
 to commit `c6a2128271532746a5570b99ce0ccdea4618db4e`, installs the evaluation
 package, and runs as an unprivileged user.
 
 ```bash
-docker build -t llm-evaluation-lab:0.7 .
+docker build -t llm-evaluation-lab:0.8 .
 
-docker run --rm llm-evaluation-lab:0.7 \
+docker run --rm llm-evaluation-lab:0.8 \
   --suite historical \
   --cases cases/anonymized/premature-parent-closure.md
 ```
@@ -153,16 +155,45 @@ docker run --rm \
   -p 127.0.0.1:8000:8000 \
   -v /absolute/path/to/data:/data:ro \
   --entrypoint llm-eval-api \
-  llm-evaluation-lab:0.7 \
+  llm-evaluation-lab:0.8 \
   --store /data/eval-runs.sqlite3 \
   --host 0.0.0.0 \
   --allow-network
 ```
 
-CI builds the image from a clean checkout, verifies version `0.7.0`, executes the
+CI builds the image from a clean checkout, verifies version `0.8.0`, executes the
 24-case historical regression, creates a mounted SQLite record, then queries the
 containerized API over HTTP. This is reproducible local packaging, not a published
 registry image or production deployment.
+
+## SEARCH-CUP-02 Offline Fairness Harness v0.8
+
+`ENG-SC-01-P0` adds a closed-book, provider-neutral search-benchmark skeleton.
+It is intentionally offline: four deterministic fake entrants receive the same
+canonical Candidate Card and CompetitionSpec; each gets an isolated search tool
+with a hard 20-call budget; submissions are frozen and SHA-256 hashed before a
+synthetic hidden registry can be opened; the judge then produces a deterministic
+dimension-preserving scoreboard.
+
+```bash
+llm-search-cup preflight
+llm-search-cup demo --format markdown
+```
+
+The P0 CLI contains no live provider adapter, real search backend, credential
+path, or official-match command. It cannot spend model/search quota or run the
+authorized-but-not-approved 80-search-call match. The included employers, URLs,
+registry, and scores are synthetic fixtures and are not job leads.
+
+P0 evidence:
+
+- call 21 is rejected before the backend executes;
+- failed backend attempts consume one explicit budget event;
+- all four successful submissions share identical contract fingerprints;
+- one provider failure preserves other entrants' frozen evidence;
+- hidden-registry access fails until all four submissions are frozen and entrant execution is closed;
+- repeated judging is byte-identical and requires no model call;
+- Apply-Now errors receive the specified 2× penalty.
 
 ## Executable integration v0.3
 
@@ -222,6 +253,8 @@ boundary explicit: Eval Lab specifies and verifies; Companion-Mind implements.
 ## Artifact map
 
 - `evaluation_lab.py` — loader, policies, grader, metrics, regression gate, CLI, and read-only API
+- `search_cup/` — P0 contracts, budgeted tools, fake providers, isolated runner, hidden judge, and offline CLI
+- `candidates/` and `competitions/` — canonical public-safe P0 inputs and fingerprints
 - `cases/anonymized/premature-parent-closure.md` — first-loop case card plus executable 24-case historical benchmark
 - `experiments/closure-guard-mitigation.md` — mitigation, decision rule, and executable JSON contract
 - `results/EVAL-CASE-001.json` — checked deterministic result
@@ -231,9 +264,10 @@ boundary explicit: Eval Lab specifies and verifies; Companion-Mind implements.
 
 ## Roadmap
 
-**Operationalization baseline complete** — SQLite experiment tracking, structured
-logging, a read-only FastAPI query surface, and Docker CLI/API reproduction are
-implemented. Further infrastructure expansion requires a separate scope decision.
+**SEARCH-CUP-02 P0 complete; live phases locked** — the fully offline fairness
+harness is implemented. SearchProxy integration, live provider adapters, immutable
+SQLite match evidence, the private judge snapshot, and any paid official match
+remain separate gated phases under Issue #8.
 
 ## Privacy
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -29,7 +29,7 @@ companion-mind validate-mitigation --mitigation-spec /tmp/mitigation.json
 
 `llm-eval` 现在负责校验并输出完整的 `mitigation-spec/v1`，再用它实例化 Companion-Mind 的真实 `ClosureGuard`。报告同时记录 runtime 实际加载的 mitigation ID、safeguard ID、schema version 与 canonical SHA-256 fingerprint，从而证明“写入评测报告的配置”与“运行时真正执行的配置”一致。
 
-当前 **32/32 tests** 覆盖 Case/Spec 同步、非法规范、状态集合冲突、真实 runtime 回归、checked result、历史机制簇、最小对照、隐私定位符、双套 suite 的 SQLite 持久化、重复 run 防覆盖、结构化日志、只读 API、双格式报告、CLI 原子输出与退出码契约。
+原有评测主线仍保持 **32/32 tests**；加上 SEARCH-CUP-02 P0 的 **21/21** 项，当前全仓为 **53/53**。
 
 ## Historical Failure Benchmark v0.4
 
@@ -57,20 +57,35 @@ llm-eval \
 该接口只适合本地、public-safe 实验记录查询。当前没有认证、授权、限流、
 公网部署或生产可靠性声明；操作方不得把私密提示词、档案定位符或账号信息写入实验元数据。
 
-## Docker Reproducibility v0.7
+## Docker Reproducibility（v0.7 引入）
 
 仓库新增唯一一个受控文件 `Dockerfile`，将 Companion-Mind runtime 固定在
 `c6a2128271532746a5570b99ce0ccdea4618db4e`，容器以非 root 用户运行。
 
 ```bash
-docker build -t llm-evaluation-lab:0.7 .
-docker run --rm llm-evaluation-lab:0.7 \
+docker build -t llm-evaluation-lab:0.8 .
+docker run --rm llm-evaluation-lab:0.8 \
   --suite historical \
   --cases cases/anonymized/premature-parent-closure.md
 ```
 
-GitHub Actions 会从 clean checkout 构建镜像、核验 `0.7.0`、复跑 24 案例历史基准、
+GitHub Actions 会从 clean checkout 构建镜像、核验 `0.8.0`、复跑 24 案例历史基准、
 在挂载目录中生成 SQLite 记录，并通过真实 HTTP 查询容器化 API。它证明本地容器复跑能力，
 不代表已经发布 registry image、完成云部署或达到生产可靠性。
+
+## SEARCH-CUP-02 离线公平性框架 v0.8
+
+`ENG-SC-01-P0` 已实现四名 Fake Entrant 的封闭式离线比赛：四方读取字节一致的
+Candidate Card 与 CompetitionSpec；每方拥有独立的 20 次搜索硬预算；Submission
+冻结并生成 SHA-256 后，程序才允许打开合成隐藏井表，并由无模型调用的确定性 Judge
+生成保留各评分维度的榜单。
+
+```bash
+llm-search-cup preflight
+llm-search-cup demo --format markdown
+```
+
+P0 中没有 live provider adapter、真实搜索后端、密钥读取路径或正式比赛命令，不能触发
+四模型 80 次搜索。示例公司、网址、隐藏井表与分数全部是离线合成夹具，不是真实岗位。
 
 第三仓仍保留 concept growth、prior lock-in、world-model drift、longitudinal evolution 与 experimental timeline；failure taxonomy 只是公开接口，不取代纵向评估内核。

--- a/candidates/curator-jieyi-pan.public-safe.json
+++ b/candidates/curator-jieyi-pan.public-safe.json
@@ -1,0 +1,114 @@
+{
+  "candidate_id": "CURATOR-JIEYI-PAN",
+  "legal_name": "Jieyi Pan / 潘劼毅",
+  "technical_name": "Aeren Kolstein",
+  "github": "aerenkolstein-code",
+  "base": {
+    "city": "Elda",
+    "region": "Alicante",
+    "country": "Spain",
+    "timezone": "Europe/Madrid",
+    "geography_priority": [
+      "Worldwide Remote",
+      "Europe Remote",
+      "EMEA Remote",
+      "Spain Remote"
+    ],
+    "note": "Do not assume US work authorization or eligibility for country-restricted remote roles."
+  },
+  "languages": {
+    "Chinese": "native",
+    "English": "working-professional",
+    "Spanish": "not_work_ready"
+  },
+  "education_and_background": [
+    "East China Normal University, Biology / teacher-training background, 1998-2002",
+    "Fudan University, second bachelor's degree in Computer Technology, 2005-2007",
+    "early-career C/C++ software development experience",
+    "long career interruption followed by an active return to software/AI engineering in 2026"
+  ],
+  "current_positioning": {
+    "primary_identity": "AI Evaluation & LLM Systems / Applied AI engineering candidate",
+    "strengths": [
+      "reproducible LLM evaluation design",
+      "model-behavior and continuity testing",
+      "stateful LLM runtime architecture",
+      "Python engineering",
+      "experiment provenance and auditability",
+      "GitHub Actions / CI",
+      "SQLite experiment tracking",
+      "read-only API surface",
+      "Docker reproducibility",
+      "technical writing and evidence-oriented engineering",
+      "Chinese-language / cross-lingual AI evaluation relevance"
+    ]
+  },
+  "portfolio": [
+    {
+      "repo": "aerenkolstein-code/llm-evaluation-lab",
+      "status": "public; main has merged engineering through v0.7",
+      "evidence": [
+        "reproducible evaluation CLI",
+        "executable cross-repository MitigationSpec integration",
+        "24-case public-safe Historical Failure Benchmark",
+        "immutable SQLite experiment tracking",
+        "read-only FastAPI query surface",
+        "Docker reproducibility and CI validation"
+      ]
+    },
+    {
+      "repo": "aerenkolstein-code/Companion-Mind",
+      "status": "public; core runtime merged; persona-continuity work remains auditable",
+      "evidence": [
+        "replayable stateful runtime",
+        "append-only evidence/provenance",
+        "runtime safeguard contracts",
+        "provider-independent persona/session experiments",
+        "real model API evaluation",
+        "cross-model Native persona-continuity diagnostics",
+        "current public test suite at 55/55 on the active diagnostic branch"
+      ]
+    }
+  ],
+  "current_target_roles": {
+    "priority_1": [
+      "AI Evaluation Engineer",
+      "LLM Evaluation Engineer",
+      "Model Evaluation / Model Behavior",
+      "AI Quality / AI QA",
+      "Prompt QA / Prompt Evaluation",
+      "Agent Evaluation",
+      "AI Reliability / LLM Reliability"
+    ],
+    "priority_2": [
+      "Applied AI Engineer",
+      "LLM Systems Engineer",
+      "AI Application Engineer",
+      "LLM Ops / Agent Ops where evaluation or reliability is central"
+    ],
+    "priority_3": [
+      "higher-value AI evaluator / reviewer / contractor roles requiring technical or domain judgment"
+    ]
+  },
+  "fit_constraints": {
+    "prefer": [
+      "remote roles open from Spain, Europe, EMEA, or worldwide",
+      "roles where the two public GitHub repositories are relevant evidence",
+      "evaluation, reliability, behavior, applied-LLM, agent, QA, and systems work",
+      "junior, associate, or non-senior-exclusive engineering roles",
+      "full-time, part-time, or contractor arrangements with meaningful technical work"
+    ],
+    "deprioritize": [
+      "Spanish-mandatory professional roles",
+      "US-only remote employment",
+      "senior-only, staff, or principal ML roles requiring many recent production years",
+      "frontier-model research roles requiring PhD publication records",
+      "low-value surveys or generic microtasks when a direct AI role is available"
+    ]
+  },
+  "search_intent": {
+    "primary": "discover new direct employers and higher-value AI opportunities globally",
+    "secondary": "discover credible contractor or project pools with stronger AI-evaluation or applied-LLM content",
+    "hidden_registry_rule": "entrants must not see the current drilling table before submission freeze"
+  }
+}

--- a/competitions/search-cup-02.offline.json
+++ b/competitions/search-cup-02.offline.json
@@ -1,0 +1,37 @@
+{
+  "competition_id": "SEARCH-CUP-02-P0-OFFLINE",
+  "task": "Find up to 20 currently worth-considering AI work opportunities worldwide for this candidate, using no more than 20 web-search calls. Independently allocate discovery and verification. Return the full ranked lead set plus the five opportunities the candidate should review first.",
+  "search_backend_id": "fake-search-pro-offline",
+  "max_search_calls": 20,
+  "official_match_authorized": false,
+  "entrants": [
+    {
+      "entrant_id": "openai-offline",
+      "provider": "OpenAI",
+      "exact_model_id": "fake-openai-p0",
+      "endpoint_mode": "offline-fixture",
+      "sampling": {"temperature": 0}
+    },
+    {
+      "entrant_id": "gemini-offline",
+      "provider": "Gemini",
+      "exact_model_id": "fake-gemini-p0",
+      "endpoint_mode": "offline-fixture",
+      "sampling": {"temperature": 0}
+    },
+    {
+      "entrant_id": "deepseek-offline",
+      "provider": "DeepSeek",
+      "exact_model_id": "fake-deepseek-p0",
+      "endpoint_mode": "offline-fixture",
+      "sampling": {"temperature": 0}
+    },
+    {
+      "entrant_id": "glm-offline",
+      "provider": "GLM",
+      "exact_model_id": "fake-glm-p0",
+      "endpoint_mode": "offline-fixture",
+      "sampling": {"temperature": 0}
+    }
+  ]
+}

--- a/evaluation_lab.py
+++ b/evaluation_lab.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from typing import Any, Callable, Iterable, Mapping, Sequence
 
 
-__version__ = "0.7.0"
+__version__ = "0.8.0"
 
 Child = Mapping[str, str]
 Case = Mapping[str, object]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-evaluation-lab"
-version = "0.7.0"
-description = "Container-reproducible LLM evaluation harness with experiment tracking and a read-only API"
+version = "0.8.0"
+description = "Reproducible LLM evaluation harness with an offline closed-book search benchmark"
 requires-python = ">=3.11"
 dependencies = [
   "fastapi>=0.115,<1",
@@ -15,6 +15,12 @@ dependencies = [
 [project.scripts]
 llm-eval = "evaluation_lab:main"
 llm-eval-api = "evaluation_lab:serve_main"
+llm-search-cup = "search_cup.cli:main"
 
 [tool.setuptools]
 py-modules = ["evaluation_lab"]
+packages = ["search_cup"]
+
+[tool.setuptools.data-files]
+"candidates" = ["candidates/*.json"]
+"competitions" = ["competitions/*.json"]

--- a/search_cup/__init__.py
+++ b/search_cup/__init__.py
@@ -1,0 +1,30 @@
+"""Closed-book, provider-neutral search benchmark primitives."""
+
+from .contracts import (
+    CandidateCard,
+    CompetitionSpec,
+    EntrantConfig,
+    FrozenSubmission,
+    JudgeRegistrySnapshot,
+    Lead,
+    RegistryLeadAssessment,
+    Submission,
+)
+from .judge import CompetitionReport, HiddenRegistryGate, judge_match
+from .runner import MatchRun, run_match
+
+__all__ = [
+    "CandidateCard",
+    "CompetitionReport",
+    "CompetitionSpec",
+    "EntrantConfig",
+    "FrozenSubmission",
+    "HiddenRegistryGate",
+    "JudgeRegistrySnapshot",
+    "Lead",
+    "MatchRun",
+    "RegistryLeadAssessment",
+    "Submission",
+    "judge_match",
+    "run_match",
+]

--- a/search_cup/cli.py
+++ b/search_cup/cli.py
@@ -1,0 +1,60 @@
+"""P0-only CLI. It intentionally exposes no paid/live match command."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Sequence
+
+from .contracts import CandidateCard, CompetitionSpec
+from .demo import DEFAULT_CANDIDATE, DEFAULT_COMPETITION, build_offline_demo
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="llm-search-cup")
+    subcommands = parser.add_subparsers(dest="command", required=True)
+
+    preflight = subcommands.add_parser("preflight", help="validate public-safe P0 contracts")
+    preflight.add_argument("--candidate", default=str(DEFAULT_CANDIDATE))
+    preflight.add_argument("--competition", default=str(DEFAULT_COMPETITION))
+
+    demo = subcommands.add_parser("demo", help="run the deterministic four-entrant offline match")
+    demo.add_argument("--candidate", default=str(DEFAULT_CANDIDATE))
+    demo.add_argument("--competition", default=str(DEFAULT_COMPETITION))
+    demo.add_argument("--format", choices=("json", "markdown"), default="json")
+    demo.add_argument("--output")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    if args.command == "preflight":
+        candidate = CandidateCard.load(args.candidate)
+        competition = CompetitionSpec.load(args.competition)
+        if competition.official_match_authorized:
+            raise ValueError("P0 preflight refuses an authorized official-match spec")
+        result = {
+            "phase": "ENG-SC-01-P0",
+            "mode": "OFFLINE_ONLY",
+            "candidate_fingerprint": candidate.fingerprint,
+            "competition_fingerprint": competition.fingerprint,
+            "entrant_count": len(competition.entrants),
+            "search_budget_per_entrant": competition.max_search_calls,
+            "official_match_authorized": competition.official_match_authorized,
+            "live_provider_adapters": 0,
+        }
+        print(json.dumps(result, indent=2, sort_keys=True))
+        return 0
+
+    _, _, report = build_offline_demo(args.candidate, args.competition)
+    rendered = report.render_json() if args.format == "json" else report.render_markdown()
+    if args.output:
+        Path(args.output).write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/search_cup/contracts.py
+++ b/search_cup/contracts.py
@@ -1,0 +1,515 @@
+"""Immutable, canonical contracts for SEARCH-CUP-02."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass, is_dataclass
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any, Mapping, Sequence
+
+
+def _jsonable(value: object) -> object:
+    if is_dataclass(value):
+        return _jsonable(asdict(value))
+    if isinstance(value, Mapping):
+        return {str(key): _jsonable(item) for key, item in value.items()}
+    if isinstance(value, (tuple, list, set, frozenset)):
+        return [_jsonable(item) for item in value]
+    return value
+
+
+def canonical_json(value: object) -> str:
+    """Return the one canonical UTF-8 JSON representation used for hashing."""
+
+    return json.dumps(
+        _jsonable(value),
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+
+def fingerprint(value: object) -> str:
+    return hashlib.sha256(canonical_json(value).encode("utf-8")).hexdigest()
+
+
+def _required_text(value: object, label: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{label} must be a non-empty string")
+    return value.strip()
+
+
+def _required_bool(value: object, label: str) -> bool:
+    if not isinstance(value, bool):
+        raise ValueError(f"{label} must be boolean")
+    return value
+
+
+def _string_tuple(value: object, label: str, *, allow_empty: bool = False) -> tuple[str, ...]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        raise ValueError(f"{label} must be an array")
+    normalized = tuple(_required_text(item, f"{label}[]") for item in value)
+    if not normalized and not allow_empty:
+        raise ValueError(f"{label} must not be empty")
+    return normalized
+
+
+FORBIDDEN_CANDIDATE_KEYS = frozenset(
+    {
+        "account_data",
+        "credentials",
+        "family",
+        "financial",
+        "google_drive",
+        "health",
+        "l0",
+        "private_archive",
+        "raw",
+        "relationship",
+    }
+)
+
+
+def _scan_forbidden_keys(value: object, path: str = "candidate") -> None:
+    if isinstance(value, Mapping):
+        for key, item in value.items():
+            normalized = str(key).strip().lower()
+            if normalized in FORBIDDEN_CANDIDATE_KEYS:
+                raise ValueError(f"{path}.{key}: private field is not allowed")
+            _scan_forbidden_keys(item, f"{path}.{key}")
+    elif isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        for index, item in enumerate(value):
+            _scan_forbidden_keys(item, f"{path}[{index}]")
+
+
+@dataclass(frozen=True)
+class CandidateCard:
+    """Public-safe candidate context stored as canonical content."""
+
+    canonical_content: str
+    fingerprint: str
+
+    @classmethod
+    def from_mapping(cls, document: Mapping[str, object]) -> "CandidateCard":
+        _scan_forbidden_keys(document)
+        _required_text(document.get("candidate_id"), "candidate_id")
+        _required_text(document.get("legal_name"), "legal_name")
+        _required_text(document.get("technical_name"), "technical_name")
+        base = document.get("base")
+        languages = document.get("languages")
+        positioning = document.get("current_positioning")
+        targets = document.get("current_target_roles")
+        if not all(isinstance(item, Mapping) for item in (base, languages, positioning, targets)):
+            raise ValueError("candidate card is missing a required profile section")
+        content = canonical_json(document)
+        return cls(
+            canonical_content=content,
+            fingerprint=hashlib.sha256(content.encode("utf-8")).hexdigest(),
+        )
+
+    @classmethod
+    def load(cls, path: str | Path) -> "CandidateCard":
+        document = json.loads(Path(path).read_text(encoding="utf-8"))
+        if not isinstance(document, dict):
+            raise ValueError("candidate card must be a JSON object")
+        return cls.from_mapping(document)
+
+    @property
+    def canonical_bytes(self) -> bytes:
+        return self.canonical_content.encode("utf-8")
+
+    def as_dict(self) -> Mapping[str, object]:
+        return MappingProxyType(json.loads(self.canonical_content))
+
+
+@dataclass(frozen=True)
+class EntrantConfig:
+    entrant_id: str
+    provider: str
+    exact_model_id: str
+    endpoint_mode: str
+    sampling_json: str
+
+    @classmethod
+    def from_mapping(cls, document: Mapping[str, object]) -> "EntrantConfig":
+        sampling = document.get("sampling", {})
+        if not isinstance(sampling, Mapping):
+            raise ValueError("entrant sampling must be an object")
+        return cls(
+            entrant_id=_required_text(document.get("entrant_id"), "entrant_id"),
+            provider=_required_text(document.get("provider"), "provider"),
+            exact_model_id=_required_text(document.get("exact_model_id"), "exact_model_id"),
+            endpoint_mode=_required_text(document.get("endpoint_mode"), "endpoint_mode"),
+            sampling_json=canonical_json(sampling),
+        )
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "entrant_id": self.entrant_id,
+            "provider": self.provider,
+            "exact_model_id": self.exact_model_id,
+            "endpoint_mode": self.endpoint_mode,
+            "sampling": json.loads(self.sampling_json),
+        }
+
+
+@dataclass(frozen=True)
+class CompetitionSpec:
+    competition_id: str
+    task: str
+    max_search_calls: int
+    search_backend_id: str
+    official_match_authorized: bool
+    entrants: tuple[EntrantConfig, ...]
+    canonical_content: str
+    fingerprint: str
+
+    @classmethod
+    def from_mapping(cls, document: Mapping[str, object]) -> "CompetitionSpec":
+        competition_id = _required_text(document.get("competition_id"), "competition_id")
+        task = _required_text(document.get("task"), "task")
+        backend = _required_text(document.get("search_backend_id"), "search_backend_id")
+        budget = document.get("max_search_calls")
+        if not isinstance(budget, int) or isinstance(budget, bool) or budget != 20:
+            raise ValueError("SEARCH-CUP-02 requires max_search_calls == 20")
+        authorized = document.get("official_match_authorized")
+        if not isinstance(authorized, bool):
+            raise ValueError("official_match_authorized must be boolean")
+        raw_entrants = document.get("entrants")
+        if not isinstance(raw_entrants, list) or len(raw_entrants) != 4:
+            raise ValueError("SEARCH-CUP-02 requires exactly four entrants")
+        entrants = tuple(
+            EntrantConfig.from_mapping(item)
+            for item in raw_entrants
+            if isinstance(item, Mapping)
+        )
+        if len(entrants) != 4:
+            raise ValueError("every entrant must be an object")
+        entrant_ids = [item.entrant_id for item in entrants]
+        providers = [item.provider.lower() for item in entrants]
+        if len(set(entrant_ids)) != 4 or len(set(providers)) != 4:
+            raise ValueError("entrant IDs and providers must be unique")
+        if set(providers) != {"openai", "gemini", "deepseek", "glm"}:
+            raise ValueError("entrants must be OpenAI, Gemini, DeepSeek, and GLM")
+        content = canonical_json(document)
+        return cls(
+            competition_id=competition_id,
+            task=task,
+            max_search_calls=budget,
+            search_backend_id=backend,
+            official_match_authorized=authorized,
+            entrants=entrants,
+            canonical_content=content,
+            fingerprint=hashlib.sha256(content.encode("utf-8")).hexdigest(),
+        )
+
+    @classmethod
+    def load(cls, path: str | Path) -> "CompetitionSpec":
+        document = json.loads(Path(path).read_text(encoding="utf-8"))
+        if not isinstance(document, dict):
+            raise ValueError("competition spec must be a JSON object")
+        return cls.from_mapping(document)
+
+    @property
+    def canonical_bytes(self) -> bytes:
+        return self.canonical_content.encode("utf-8")
+
+
+@dataclass(frozen=True)
+class SearchRequest:
+    entrant_id: str
+    query: str
+
+    def __post_init__(self) -> None:
+        _required_text(self.entrant_id, "entrant_id")
+        _required_text(self.query, "query")
+
+
+@dataclass(frozen=True)
+class SearchResult:
+    title: str
+    url: str
+    snippet: str
+
+    def __post_init__(self) -> None:
+        _required_text(self.title, "search result title")
+        _required_text(self.url, "search result URL")
+
+
+@dataclass(frozen=True)
+class SearchTrace:
+    entrant_id: str
+    call_number: int
+    query: str
+    status: str
+    result_count: int
+    error_type: str | None = None
+
+
+@dataclass(frozen=True)
+class URLReadResult:
+    url: str
+    status: str
+    title: str = ""
+    text: str = ""
+
+    def __post_init__(self) -> None:
+        _required_text(self.url, "URL read URL")
+        if self.status not in {"OK", "BLOCKED", "JS_REQUIRED", "NOT_FOUND"}:
+            raise ValueError("unsupported URL read status")
+
+
+@dataclass(frozen=True)
+class Lead:
+    company: str
+    role: str
+    source_url: str
+    official_source: bool
+    open_status: str
+    remote_scope: str
+    location_constraint: str
+    employment_type: str
+    required_skills: tuple[str, ...]
+    candidate_fit: str
+    mismatch_risks: tuple[str, ...]
+    portfolio_relevance: str
+    confidence: float
+    next_action: str
+    evidence_urls: tuple[str, ...]
+    claimed_novel: bool = False
+
+    def __post_init__(self) -> None:
+        for label in (
+            "company",
+            "role",
+            "source_url",
+            "open_status",
+            "remote_scope",
+            "location_constraint",
+            "employment_type",
+            "candidate_fit",
+            "portfolio_relevance",
+            "next_action",
+        ):
+            _required_text(getattr(self, label), label)
+        if self.open_status not in {"OPEN", "CLOSED", "UNVERIFIED"}:
+            raise ValueError("open_status must be OPEN, CLOSED, or UNVERIFIED")
+        if not 0.0 <= self.confidence <= 1.0:
+            raise ValueError("confidence must be between 0 and 1")
+        if not self.evidence_urls:
+            raise ValueError("lead must include at least one evidence URL")
+
+    @property
+    def key(self) -> str:
+        return self.source_url.strip().rstrip("/").lower()
+
+    @classmethod
+    def from_mapping(cls, document: Mapping[str, object]) -> "Lead":
+        confidence = document.get("confidence")
+        if not isinstance(confidence, (int, float)) or isinstance(confidence, bool):
+            raise ValueError("confidence must be numeric")
+        return cls(
+            company=_required_text(document.get("company"), "company"),
+            role=_required_text(document.get("role"), "role"),
+            source_url=_required_text(document.get("source_url"), "source_url"),
+            official_source=_required_bool(
+                document.get("official_source"), "official_source"
+            ),
+            open_status=_required_text(document.get("open_status"), "open_status"),
+            remote_scope=_required_text(document.get("remote_scope"), "remote_scope"),
+            location_constraint=_required_text(
+                document.get("location_constraint"), "location_constraint"
+            ),
+            employment_type=_required_text(
+                document.get("employment_type"), "employment_type"
+            ),
+            required_skills=_string_tuple(
+                document.get("required_skills", []),
+                "required_skills",
+                allow_empty=True,
+            ),
+            candidate_fit=_required_text(document.get("candidate_fit"), "candidate_fit"),
+            mismatch_risks=_string_tuple(
+                document.get("mismatch_risks", []),
+                "mismatch_risks",
+                allow_empty=True,
+            ),
+            portfolio_relevance=_required_text(
+                document.get("portfolio_relevance"), "portfolio_relevance"
+            ),
+            confidence=float(confidence),
+            next_action=_required_text(document.get("next_action"), "next_action"),
+            evidence_urls=_string_tuple(document.get("evidence_urls", []), "evidence_urls"),
+            claimed_novel=_required_bool(
+                document.get("claimed_novel", False), "claimed_novel"
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class Submission:
+    entrant: EntrantConfig
+    candidate_fingerprint: str
+    competition_fingerprint: str
+    leads: tuple[Lead, ...]
+    apply_now_urls: tuple[str, ...]
+    search_strategy_summary: str
+    rejected_or_downgraded: tuple[str, ...]
+    uncertainties: tuple[str, ...]
+    search_calls: int
+
+    def __post_init__(self) -> None:
+        if len(self.leads) > 20:
+            raise ValueError("submission may contain at most 20 leads")
+        if len(self.apply_now_urls) > 5:
+            raise ValueError("submission may contain at most five Apply-Now leads")
+        lead_urls = {lead.source_url for lead in self.leads}
+        if any(url not in lead_urls for url in self.apply_now_urls):
+            raise ValueError("Apply-Now URLs must refer to submitted leads")
+        if not 0 <= self.search_calls <= 20:
+            raise ValueError("search_calls must be between 0 and 20")
+        _required_text(self.search_strategy_summary, "search_strategy_summary")
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "entrant": self.entrant.as_dict(),
+            "candidate_fingerprint": self.candidate_fingerprint,
+            "competition_fingerprint": self.competition_fingerprint,
+            "leads": [asdict(lead) for lead in self.leads],
+            "apply_now_urls": list(self.apply_now_urls),
+            "search_strategy_summary": self.search_strategy_summary,
+            "rejected_or_downgraded": list(self.rejected_or_downgraded),
+            "uncertainties": list(self.uncertainties),
+            "search_calls": self.search_calls,
+        }
+
+    @classmethod
+    def from_mapping(cls, document: Mapping[str, object]) -> "Submission":
+        raw_entrant = document.get("entrant")
+        raw_leads = document.get("leads")
+        if not isinstance(raw_entrant, Mapping) or not isinstance(raw_leads, list):
+            raise ValueError("submission is missing entrant or leads")
+        if not all(isinstance(item, Mapping) for item in raw_leads):
+            raise ValueError("every submitted lead must be an object")
+        search_calls = document.get("search_calls")
+        if not isinstance(search_calls, int) or isinstance(search_calls, bool):
+            raise ValueError("submission search_calls must be an integer")
+        return cls(
+            entrant=EntrantConfig.from_mapping(raw_entrant),
+            candidate_fingerprint=_required_text(
+                document.get("candidate_fingerprint"), "candidate_fingerprint"
+            ),
+            competition_fingerprint=_required_text(
+                document.get("competition_fingerprint"),
+                "competition_fingerprint",
+            ),
+            leads=tuple(Lead.from_mapping(item) for item in raw_leads),
+            apply_now_urls=_string_tuple(
+                document.get("apply_now_urls", []),
+                "apply_now_urls",
+                allow_empty=True,
+            ),
+            search_strategy_summary=_required_text(
+                document.get("search_strategy_summary"),
+                "search_strategy_summary",
+            ),
+            rejected_or_downgraded=_string_tuple(
+                document.get("rejected_or_downgraded", []),
+                "rejected_or_downgraded",
+                allow_empty=True,
+            ),
+            uncertainties=_string_tuple(
+                document.get("uncertainties", []),
+                "uncertainties",
+                allow_empty=True,
+            ),
+            search_calls=search_calls,
+        )
+
+
+@dataclass(frozen=True)
+class FrozenSubmission:
+    entrant_id: str
+    canonical_content: str
+    sha256: str
+
+    @classmethod
+    def freeze(cls, submission: Submission) -> "FrozenSubmission":
+        content = canonical_json(submission.as_dict())
+        return cls(
+            entrant_id=submission.entrant.entrant_id,
+            canonical_content=content,
+            sha256=hashlib.sha256(content.encode("utf-8")).hexdigest(),
+        )
+
+    def thaw_verified(self) -> Submission:
+        actual = hashlib.sha256(self.canonical_content.encode("utf-8")).hexdigest()
+        if actual != self.sha256:
+            raise ValueError("frozen submission hash mismatch")
+        document = json.loads(self.canonical_content)
+        if not isinstance(document, dict):
+            raise ValueError("frozen submission must contain an object")
+        submission = Submission.from_mapping(document)
+        if submission.entrant.entrant_id != self.entrant_id:
+            raise ValueError("frozen submission entrant mismatch")
+        return submission
+
+
+@dataclass(frozen=True)
+class RegistryLeadAssessment:
+    source_url: str
+    real_open: bool
+    practical_fit: bool
+    geography_eligible: bool
+    actionable: bool
+    primary_source: bool
+    fabricated: bool = False
+    us_only: bool = False
+    senior_or_phd_mismatch: bool = False
+
+    @property
+    def key(self) -> str:
+        return self.source_url.strip().rstrip("/").lower()
+
+
+@dataclass(frozen=True)
+class JudgeRegistrySnapshot:
+    snapshot_id: str
+    known_well_keys: tuple[str, ...]
+    assessments: tuple[RegistryLeadAssessment, ...]
+    fingerprint: str
+
+    @classmethod
+    def create(
+        cls,
+        snapshot_id: str,
+        known_well_urls: Sequence[str],
+        assessments: Sequence[RegistryLeadAssessment],
+    ) -> "JudgeRegistrySnapshot":
+        known = tuple(sorted({url.strip().rstrip("/").lower() for url in known_well_urls}))
+        assessment_tuple = tuple(sorted(assessments, key=lambda item: item.key))
+        assessment_keys = [item.key for item in assessment_tuple]
+        if len(set(assessment_keys)) != len(assessment_keys):
+            raise ValueError("judge registry assessments must have unique URLs")
+        payload = {
+            "snapshot_id": _required_text(snapshot_id, "snapshot_id"),
+            "known_well_keys": known,
+            "assessments": [asdict(item) for item in assessment_tuple],
+        }
+        return cls(
+            snapshot_id=snapshot_id,
+            known_well_keys=known,
+            assessments=assessment_tuple,
+            fingerprint=fingerprint(payload),
+        )
+
+    def verify(self) -> None:
+        payload = {
+            "snapshot_id": self.snapshot_id,
+            "known_well_keys": self.known_well_keys,
+            "assessments": [asdict(item) for item in self.assessments],
+        }
+        if fingerprint(payload) != self.fingerprint:
+            raise ValueError("judge registry snapshot hash mismatch")

--- a/search_cup/demo.py
+++ b/search_cup/demo.py
@@ -1,0 +1,129 @@
+"""Deterministic four-entrant P0 demonstration using synthetic fixtures."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from .contracts import (
+    CandidateCard,
+    CompetitionSpec,
+    JudgeRegistrySnapshot,
+    Lead,
+    RegistryLeadAssessment,
+    SearchResult,
+    URLReadResult,
+)
+from .judge import CompetitionReport, judge_match
+from .providers import FakeProvider
+from .runner import MatchRun, run_match
+
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def _data_path(directory: str, filename: str) -> Path:
+    source_tree = ROOT / directory / filename
+    if source_tree.is_file():
+        return source_tree
+    return Path(sys.prefix) / directory / filename
+
+
+DEFAULT_CANDIDATE = _data_path(
+    "candidates", "curator-jieyi-pan.public-safe.json"
+)
+DEFAULT_COMPETITION = _data_path(
+    "competitions", "search-cup-02.offline.json"
+)
+
+
+def _lead(index: int, *, known: bool = False, stale: bool = False) -> Lead:
+    url = f"https://jobs.example.test/ai-evaluation-{index}"
+    return Lead(
+        company=f"Synthetic Employer {index}",
+        role="AI Evaluation Engineer",
+        source_url=url,
+        official_source=True,
+        open_status="OPEN" if not stale else "OPEN",
+        remote_scope="Europe Remote",
+        location_constraint="Spain / Europe eligible",
+        employment_type="Contract",
+        required_skills=("Python", "LLM evaluation"),
+        candidate_fit="Public portfolio demonstrates relevant evaluation engineering.",
+        mismatch_risks=(),
+        portfolio_relevance="Directly relevant to both public repositories.",
+        confidence=0.9,
+        next_action="Human review of the synthetic official fixture.",
+        evidence_urls=(url,),
+        claimed_novel=not known,
+    )
+
+
+def build_offline_demo(
+    candidate_path: str | Path = DEFAULT_CANDIDATE,
+    competition_path: str | Path = DEFAULT_COMPETITION,
+) -> tuple[MatchRun, JudgeRegistrySnapshot, CompetitionReport]:
+    candidate = CandidateCard.load(candidate_path)
+    competition = CompetitionSpec.load(competition_path)
+    if competition.official_match_authorized:
+        raise ValueError("P0 offline demo refuses an authorized official-match spec")
+    providers: dict[str, FakeProvider] = {}
+    search_by_entrant: dict[str, dict[str, tuple[SearchResult, ...]]] = {}
+    url_by_entrant: dict[str, dict[str, URLReadResult]] = {}
+    assessments: list[RegistryLeadAssessment] = []
+    known_urls: list[str] = []
+
+    for index, entrant in enumerate(competition.entrants, start=1):
+        known = index == 2
+        stale = index == 3
+        lead = _lead(index, known=known, stale=stale)
+        query = f"synthetic ai evaluation opportunity {index}"
+        providers[entrant.entrant_id] = FakeProvider(
+            queries=(query,),
+            leads=(lead,),
+            apply_now_urls=(lead.source_url,),
+        )
+        search_by_entrant[entrant.entrant_id] = {
+            query: (
+                SearchResult(
+                    title=f"Synthetic result {index}",
+                    url=lead.source_url,
+                    snippet="Offline fixture; not a real job listing.",
+                ),
+            )
+        }
+        url_by_entrant[entrant.entrant_id] = {
+            lead.source_url: URLReadResult(
+                url=lead.source_url,
+                status="OK",
+                title=f"Synthetic role {index}",
+                text="Deterministic public-safe offline fixture.",
+            )
+        }
+        if known:
+            known_urls.append(lead.source_url)
+        assessments.append(
+            RegistryLeadAssessment(
+                source_url=lead.source_url,
+                real_open=not stale,
+                practical_fit=not stale,
+                geography_eligible=True,
+                actionable=not stale,
+                primary_source=True,
+            )
+        )
+
+    match = run_match(
+        candidate,
+        competition,
+        providers,
+        search_fixtures=lambda entrant_id: search_by_entrant[entrant_id],
+        url_fixtures=lambda entrant_id: url_by_entrant[entrant_id],
+    )
+    snapshot = JudgeRegistrySnapshot.create(
+        "SYNTHETIC-REGISTRY-P0",
+        known_urls,
+        assessments,
+    )
+    report = judge_match(match, snapshot)
+    return match, snapshot, report

--- a/search_cup/judge.py
+++ b/search_cup/judge.py
@@ -1,0 +1,312 @@
+"""Hidden-registry gate and deterministic SEARCH-CUP-02 judge."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from typing import Mapping
+
+from .contracts import (
+    JudgeRegistrySnapshot,
+    RegistryLeadAssessment,
+    canonical_json,
+    fingerprint,
+)
+from .runner import MatchRun
+
+
+class RegistryAccessDenied(RuntimeError):
+    pass
+
+
+class HiddenRegistryGate:
+    """Open the answer key only after every entrant is frozen and closed."""
+
+    @staticmethod
+    def open(
+        match: MatchRun,
+        snapshot: JudgeRegistrySnapshot,
+    ) -> JudgeRegistrySnapshot:
+        if not match.entrant_execution_closed:
+            raise RegistryAccessDenied("entrant execution is still open")
+        if not match.all_frozen:
+            raise RegistryAccessDenied(
+                "all configured entrant submissions must be frozen before judging"
+            )
+        snapshot.verify()
+        return snapshot
+
+
+@dataclass(frozen=True)
+class LeadJudgment:
+    source_url: str
+    real_open_points: float
+    practical_fit_points: float
+    novelty_points: float
+    geography_points: float
+    actionability_points: float
+    penalty: float
+    apply_now: bool
+    reasons: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class SearchBehaviorProfile:
+    entrant_id: str
+    lead_count: int
+    search_calls: int
+    precision: float
+    novelty_yield: float
+    false_well_rate: float
+    geography_error_rate: float
+
+
+@dataclass(frozen=True)
+class CompetitionScore:
+    entrant_id: str
+    provider: str
+    exact_model_id: str
+    real_open: float
+    practical_fit: float
+    novelty: float
+    geography: float
+    actionability: float
+    search_efficiency: float
+    penalties: float
+    total: float
+    submission_sha256: str
+    judgments: tuple[LeadJudgment, ...]
+    behavior: SearchBehaviorProfile
+
+
+@dataclass(frozen=True)
+class CompetitionReport:
+    competition_id: str
+    candidate_fingerprint: str
+    competition_fingerprint: str
+    registry_fingerprint: str
+    scores: tuple[CompetitionScore, ...]
+    report_fingerprint: str
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "competition_id": self.competition_id,
+            "candidate_fingerprint": self.candidate_fingerprint,
+            "competition_fingerprint": self.competition_fingerprint,
+            "registry_fingerprint": self.registry_fingerprint,
+            "scores": [asdict(score) for score in self.scores],
+            "report_fingerprint": self.report_fingerprint,
+        }
+
+    def render_json(self) -> str:
+        return (
+            json.dumps(
+                self.as_dict(), ensure_ascii=False, indent=2, sort_keys=True
+            )
+            + "\n"
+        )
+
+    def render_markdown(self) -> str:
+        lines = [
+            f"# {self.competition_id} Offline Scoreboard",
+            "",
+            f"- Candidate fingerprint: `{self.candidate_fingerprint}`",
+            f"- Competition fingerprint: `{self.competition_fingerprint}`",
+            f"- Registry fingerprint: `{self.registry_fingerprint}`",
+            f"- Report fingerprint: `{self.report_fingerprint}`",
+            "",
+            "| Entrant | Exact model | Real/open | Fit | Novelty | Geography | "
+            "Action | Efficiency | Penalties | Total |",
+            "|---|---|---:|---:|---:|---:|---:|---:|---:|---:|",
+        ]
+        for score in self.scores:
+            lines.append(
+                f"| {score.entrant_id} | {score.exact_model_id} | "
+                f"{score.real_open:.2f} | {score.practical_fit:.2f} | "
+                f"{score.novelty:.2f} | {score.geography:.2f} | "
+                f"{score.actionability:.2f} | {score.search_efficiency:.2f} | "
+                f"-{score.penalties:.2f} | **{score.total:.2f}** |"
+            )
+        lines.extend(
+            [
+                "",
+                "> Offline fake evidence only. No live model, search, "
+                "application, or production claim.",
+                "",
+            ]
+        )
+        return "\n".join(lines)
+
+
+def _assessment_map(
+    snapshot: JudgeRegistrySnapshot,
+) -> Mapping[str, RegistryLeadAssessment]:
+    return {item.key: item for item in snapshot.assessments}
+
+
+def _lead_judgment(
+    lead: object,
+    assessment: RegistryLeadAssessment,
+    known: set[str],
+    apply_now: set[str],
+) -> LeadJudgment:
+    source_url = str(getattr(lead, "source_url"))
+    key = source_url.strip().rstrip("/").lower()
+    is_apply_now = source_url in apply_now
+    multiplier = 2.0 if is_apply_now else 1.0
+    reasons: list[str] = []
+
+    if assessment.fabricated:
+        reasons.append("fabricated lead: score forced to zero")
+        return LeadJudgment(
+            source_url=source_url,
+            real_open_points=0.0,
+            practical_fit_points=0.0,
+            novelty_points=0.0,
+            geography_points=0.0,
+            actionability_points=0.0,
+            penalty=0.0,
+            apply_now=is_apply_now,
+            reasons=tuple(reasons),
+        )
+
+    penalty = 0.0
+    open_status = str(getattr(lead, "open_status"))
+    claimed_novel = bool(getattr(lead, "claimed_novel"))
+    official_source = bool(getattr(lead, "official_source"))
+    remote_scope = str(getattr(lead, "remote_scope")).lower()
+    if not assessment.real_open and open_status == "OPEN":
+        penalty += 5.0 * multiplier
+        reasons.append("closed/stale role reported as open")
+    if assessment.us_only and any(term in remote_scope for term in ("world", "europe", "emea")):
+        penalty += 8.0 * multiplier
+        reasons.append("US-only role overstated as geographically applicable")
+    if assessment.senior_or_phd_mismatch:
+        penalty += 5.0 * multiplier
+        reasons.append("senior/PhD mismatch sold as fit")
+    if key in known and claimed_novel:
+        penalty += 3.0 * multiplier
+        reasons.append("known well presented as novel")
+    if not assessment.primary_source or not official_source:
+        penalty += 3.0 * multiplier
+        reasons.append("credible primary source missing")
+
+    return LeadJudgment(
+        source_url=source_url,
+        real_open_points=25.0 if assessment.real_open else 0.0,
+        practical_fit_points=25.0 if assessment.practical_fit else 0.0,
+        novelty_points=20.0 if key not in known else 0.0,
+        geography_points=15.0 if assessment.geography_eligible else 0.0,
+        actionability_points=10.0 if assessment.actionable else 0.0,
+        penalty=penalty,
+        apply_now=is_apply_now,
+        reasons=tuple(reasons),
+    )
+
+
+def judge_match(
+    match: MatchRun,
+    snapshot: JudgeRegistrySnapshot,
+) -> CompetitionReport:
+    """Score frozen evidence only; this function performs no tool/model call."""
+
+    opened = HiddenRegistryGate.open(match, snapshot)
+    assessments = _assessment_map(opened)
+    known = set(opened.known_well_keys)
+    scores: list[CompetitionScore] = []
+    for outcome in match.frozen_outcomes:
+        frozen = outcome.frozen_submission
+        if frozen is None:
+            raise ValueError("frozen outcome is missing evidence")
+        submission = frozen.thaw_verified()
+        apply_now = set(submission.apply_now_urls)
+        judgments: list[LeadJudgment] = []
+        for lead in submission.leads:
+            assessment = assessments.get(lead.key)
+            if assessment is None:
+                assessment = RegistryLeadAssessment(
+                    source_url=lead.source_url,
+                    real_open=False,
+                    practical_fit=False,
+                    geography_eligible=False,
+                    actionable=False,
+                    primary_source=False,
+                )
+            judgments.append(_lead_judgment(lead, assessment, known, apply_now))
+
+        count = len(judgments)
+        divisor = float(count or 1)
+        real = sum(item.real_open_points for item in judgments) / divisor
+        fit = sum(item.practical_fit_points for item in judgments) / divisor
+        novelty = sum(item.novelty_points for item in judgments) / divisor
+        geography = sum(item.geography_points for item in judgments) / divisor
+        action = sum(item.actionability_points for item in judgments) / divisor
+        penalties = sum(item.penalty for item in judgments) / divisor
+        valid_actionable = sum(
+            item.real_open_points > 0 and item.actionability_points > 0
+            for item in judgments
+        )
+        efficiency = 5.0 * min(
+            1.0,
+            valid_actionable / max(1, submission.search_calls),
+        )
+        total = max(
+            0.0,
+            min(
+                100.0,
+                real
+                + fit
+                + novelty
+                + geography
+                + action
+                + efficiency
+                - penalties,
+            ),
+        )
+        false_wells = sum(item.real_open_points == 0 for item in judgments)
+        geo_errors = sum(item.geography_points == 0 for item in judgments)
+        novel = sum(item.novelty_points > 0 for item in judgments)
+        behavior = SearchBehaviorProfile(
+            entrant_id=outcome.entrant_id,
+            lead_count=count,
+            search_calls=submission.search_calls,
+            precision=(count - false_wells) / divisor,
+            novelty_yield=novel / max(1, submission.search_calls),
+            false_well_rate=false_wells / divisor,
+            geography_error_rate=geo_errors / divisor,
+        )
+        scores.append(
+            CompetitionScore(
+                entrant_id=outcome.entrant_id,
+                provider=submission.entrant.provider,
+                exact_model_id=submission.entrant.exact_model_id,
+                real_open=real,
+                practical_fit=fit,
+                novelty=novelty,
+                geography=geography,
+                actionability=action,
+                search_efficiency=efficiency,
+                penalties=penalties,
+                total=total,
+                submission_sha256=frozen.sha256,
+                judgments=tuple(judgments),
+                behavior=behavior,
+            )
+        )
+
+    ordered = tuple(sorted(scores, key=lambda item: (-item.total, item.entrant_id)))
+    payload = {
+        "competition_id": match.competition_id,
+        "candidate_fingerprint": match.candidate_fingerprint,
+        "competition_fingerprint": match.competition_fingerprint,
+        "registry_fingerprint": opened.fingerprint,
+        "scores": [asdict(item) for item in ordered],
+    }
+    return CompetitionReport(
+        competition_id=match.competition_id,
+        candidate_fingerprint=match.candidate_fingerprint,
+        competition_fingerprint=match.competition_fingerprint,
+        registry_fingerprint=opened.fingerprint,
+        scores=ordered,
+        report_fingerprint=fingerprint(payload),
+    )

--- a/search_cup/providers.py
+++ b/search_cup/providers.py
@@ -1,0 +1,89 @@
+"""Entrant adapter contract and deterministic offline providers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+from .contracts import EntrantConfig, Lead, Submission
+from .tools import EntrantTools
+
+
+class EntrantProvider(Protocol):
+    """Provider adapters may translate syntax, but receive identical semantics."""
+
+    def run(
+        self,
+        *,
+        candidate_content: bytes,
+        competition_content: bytes,
+        candidate_fingerprint: str,
+        competition_fingerprint: str,
+        entrant: EntrantConfig,
+        tools: EntrantTools,
+    ) -> Submission: ...
+
+
+@dataclass(frozen=True)
+class FakeProvider:
+    """Offline entrant used to verify orchestration without model API calls."""
+
+    queries: tuple[str, ...]
+    leads: tuple[Lead, ...]
+    apply_now_urls: tuple[str, ...]
+    search_strategy_summary: str = "offline deterministic discovery and verification"
+    rejected_or_downgraded: tuple[str, ...] = ()
+    uncertainties: tuple[str, ...] = ()
+
+    def run(
+        self,
+        *,
+        candidate_content: bytes,
+        competition_content: bytes,
+        candidate_fingerprint: str,
+        competition_fingerprint: str,
+        entrant: EntrantConfig,
+        tools: EntrantTools,
+    ) -> Submission:
+        if not candidate_content or not competition_content:
+            raise ValueError("canonical candidate and competition content are required")
+        for query in self.queries:
+            results = tools.search_web(query)
+            for result in results:
+                tools.read_url(result.url)
+        return Submission(
+            entrant=entrant,
+            candidate_fingerprint=candidate_fingerprint,
+            competition_fingerprint=competition_fingerprint,
+            leads=self.leads,
+            apply_now_urls=self.apply_now_urls,
+            search_strategy_summary=self.search_strategy_summary,
+            rejected_or_downgraded=self.rejected_or_downgraded,
+            uncertainties=self.uncertainties,
+            search_calls=tools.search_calls,
+        )
+
+@dataclass(frozen=True)
+class FailingFakeProvider:
+    """Fault injection adapter for provider-isolation tests."""
+
+    message: str = "injected provider failure"
+
+    def run(self, **_: object) -> Submission:
+        raise RuntimeError(self.message)
+
+
+class LiveProviderNotImplemented(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class LockedLiveProvider:
+    """Explicit P0 stop: no paid/live provider can execute from this branch."""
+
+    provider: str
+
+    def run(self, **_: object) -> Submission:
+        raise LiveProviderNotImplemented(
+            f"{self.provider}: live adapters are outside ENG-SC-01-P0"
+        )

--- a/search_cup/runner.py
+++ b/search_cup/runner.py
@@ -1,0 +1,142 @@
+"""Closed-book, provider-isolated match runner."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Mapping
+
+from .contracts import (
+    CandidateCard,
+    CompetitionSpec,
+    FrozenSubmission,
+    SearchResult,
+    SearchTrace,
+    URLReadResult,
+)
+from .providers import EntrantProvider
+from .tools import BudgetedSearchProxy, EntrantTools, FakeSearchBackend, FakeURLReader
+
+
+SearchFixtures = Mapping[str, tuple[SearchResult, ...]]
+URLFixtures = Mapping[str, URLReadResult]
+SearchFixtureFactory = Callable[[str], SearchFixtures]
+URLFixtureFactory = Callable[[str], URLFixtures]
+
+
+@dataclass(frozen=True)
+class EntrantOutcome:
+    entrant_id: str
+    status: str
+    frozen_submission: FrozenSubmission | None
+    traces: tuple[SearchTrace, ...]
+    error_type: str | None = None
+    error_message: str | None = None
+
+
+@dataclass(frozen=True)
+class MatchRun:
+    competition_id: str
+    candidate_fingerprint: str
+    competition_fingerprint: str
+    expected_entrant_ids: tuple[str, ...]
+    outcomes: tuple[EntrantOutcome, ...]
+    entrant_execution_closed: bool
+
+    @property
+    def frozen_outcomes(self) -> tuple[EntrantOutcome, ...]:
+        return tuple(item for item in self.outcomes if item.status == "FROZEN")
+
+    @property
+    def failed_outcomes(self) -> tuple[EntrantOutcome, ...]:
+        return tuple(item for item in self.outcomes if item.status == "FAILED")
+
+    @property
+    def all_frozen(self) -> bool:
+        return (
+            self.entrant_execution_closed
+            and len(self.outcomes) == len(self.expected_entrant_ids)
+            and all(item.status == "FROZEN" for item in self.outcomes)
+        )
+
+
+def run_match(
+    candidate: CandidateCard,
+    competition: CompetitionSpec,
+    providers: Mapping[str, EntrantProvider],
+    *,
+    search_fixtures: SearchFixtureFactory,
+    url_fixtures: URLFixtureFactory,
+) -> MatchRun:
+    """Run all entrants independently and preserve evidence from partial success."""
+
+    outcomes: list[EntrantOutcome] = []
+    expected = tuple(item.entrant_id for item in competition.entrants)
+    for entrant in competition.entrants:
+        proxy = BudgetedSearchProxy(
+            entrant_id=entrant.entrant_id,
+            max_calls=competition.max_search_calls,
+            backend=FakeSearchBackend(search_fixtures(entrant.entrant_id)),
+        )
+        tools = EntrantTools(
+            search_proxy=proxy,
+            url_reader=FakeURLReader(url_fixtures(entrant.entrant_id)),
+        )
+        provider = providers.get(entrant.entrant_id)
+        if provider is None:
+            outcomes.append(
+                EntrantOutcome(
+                    entrant_id=entrant.entrant_id,
+                    status="FAILED",
+                    frozen_submission=None,
+                    traces=(),
+                    error_type="MissingProvider",
+                    error_message="no provider adapter configured",
+                )
+            )
+            continue
+        try:
+            submission = provider.run(
+                candidate_content=candidate.canonical_bytes,
+                competition_content=competition.canonical_bytes,
+                candidate_fingerprint=candidate.fingerprint,
+                competition_fingerprint=competition.fingerprint,
+                entrant=entrant,
+                tools=tools,
+            )
+            if submission.entrant != entrant:
+                raise ValueError("provider changed entrant identity or configuration")
+            if submission.candidate_fingerprint != candidate.fingerprint:
+                raise ValueError("provider returned a different Candidate Card fingerprint")
+            if submission.competition_fingerprint != competition.fingerprint:
+                raise ValueError("provider returned a different CompetitionSpec fingerprint")
+            if submission.search_calls != tools.search_calls:
+                raise ValueError("provider search-call count does not match tool trace")
+            frozen = FrozenSubmission.freeze(submission)
+            outcomes.append(
+                EntrantOutcome(
+                    entrant_id=entrant.entrant_id,
+                    status="FROZEN",
+                    frozen_submission=frozen,
+                    traces=tools.traces,
+                )
+            )
+        except Exception as exc:
+            outcomes.append(
+                EntrantOutcome(
+                    entrant_id=entrant.entrant_id,
+                    status="FAILED",
+                    frozen_submission=None,
+                    traces=tools.traces,
+                    error_type=type(exc).__name__,
+                    error_message=str(exc),
+                )
+            )
+
+    return MatchRun(
+        competition_id=competition.competition_id,
+        candidate_fingerprint=candidate.fingerprint,
+        competition_fingerprint=competition.fingerprint,
+        expected_entrant_ids=expected,
+        outcomes=tuple(outcomes),
+        entrant_execution_closed=True,
+    )

--- a/search_cup/tools.py
+++ b/search_cup/tools.py
@@ -1,0 +1,117 @@
+"""Provider-neutral, budgeted tool boundary for SEARCH-CUP-02."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Mapping, Sequence
+
+from .contracts import SearchRequest, SearchResult, SearchTrace, URLReadResult
+
+
+class SearchBudgetExceeded(RuntimeError):
+    """Raised before any backend call when an entrant has spent all tickets."""
+
+
+SearchBackend = Callable[[SearchRequest], Sequence[SearchResult]]
+
+
+class BudgetedSearchProxy:
+    """Count every attempted backend call exactly once and reject call 21."""
+
+    def __init__(
+        self,
+        entrant_id: str,
+        max_calls: int,
+        backend: SearchBackend,
+    ) -> None:
+        if max_calls < 1:
+            raise ValueError("max_calls must be positive")
+        self._entrant_id = entrant_id
+        self._max_calls = max_calls
+        self._backend = backend
+        self._traces: list[SearchTrace] = []
+
+    @property
+    def traces(self) -> tuple[SearchTrace, ...]:
+        return tuple(self._traces)
+
+    @property
+    def calls_used(self) -> int:
+        return len(self._traces)
+
+    def search(self, query: str) -> tuple[SearchResult, ...]:
+        if self.calls_used >= self._max_calls:
+            raise SearchBudgetExceeded(
+                f"{self._entrant_id}: search call {self.calls_used + 1} rejected; "
+                f"budget is {self._max_calls}"
+            )
+        request = SearchRequest(entrant_id=self._entrant_id, query=query)
+        call_number = self.calls_used + 1
+        try:
+            results = tuple(self._backend(request))
+        except Exception as exc:
+            self._traces.append(
+                SearchTrace(
+                    entrant_id=self._entrant_id,
+                    call_number=call_number,
+                    query=query,
+                    status="FAILED",
+                    result_count=0,
+                    error_type=type(exc).__name__,
+                )
+            )
+            raise
+        self._traces.append(
+            SearchTrace(
+                entrant_id=self._entrant_id,
+                call_number=call_number,
+                query=query,
+                status="SUCCEEDED",
+                result_count=len(results),
+            )
+        )
+        return results
+
+
+class FakeSearchBackend:
+    """Offline backend whose complete result set is supplied by a fixture."""
+
+    def __init__(self, results_by_query: Mapping[str, Sequence[SearchResult]]) -> None:
+        self._results = {
+            query: tuple(results) for query, results in results_by_query.items()
+        }
+
+    def __call__(self, request: SearchRequest) -> tuple[SearchResult, ...]:
+        return self._results.get(request.query, ())
+
+
+class FakeURLReader:
+    """Offline URL reader with typed outcomes and no network fallback."""
+
+    def __init__(self, results_by_url: Mapping[str, URLReadResult]) -> None:
+        self._results = dict(results_by_url)
+
+    def read(self, url: str) -> URLReadResult:
+        return self._results.get(url, URLReadResult(url=url, status="NOT_FOUND"))
+
+
+@dataclass(frozen=True)
+class EntrantTools:
+    """The only tool surface passed to an entrant; it has no registry handle."""
+
+    search_proxy: BudgetedSearchProxy
+    url_reader: FakeURLReader
+
+    def search_web(self, query: str) -> tuple[SearchResult, ...]:
+        return self.search_proxy.search(query)
+
+    def read_url(self, url: str) -> URLReadResult:
+        return self.url_reader.read(url)
+
+    @property
+    def search_calls(self) -> int:
+        return self.search_proxy.calls_used
+
+    @property
+    def traces(self) -> tuple[SearchTrace, ...]:
+        return self.search_proxy.traces

--- a/tests/test_search_cup.py
+++ b/tests/test_search_cup.py
@@ -1,0 +1,302 @@
+"""ENG-SC-01-P0 offline fairness and determinism gates."""
+
+from __future__ import annotations
+
+import dataclasses
+import io
+import json
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+
+from search_cup.cli import main as search_cup_main
+from search_cup.contracts import (
+    CandidateCard,
+    CompetitionSpec,
+    FrozenSubmission,
+    JudgeRegistrySnapshot,
+    Lead,
+    RegistryLeadAssessment,
+    SearchResult,
+    Submission,
+    URLReadResult,
+)
+from search_cup.demo import (
+    DEFAULT_CANDIDATE,
+    DEFAULT_COMPETITION,
+    build_offline_demo,
+)
+from search_cup.judge import HiddenRegistryGate, RegistryAccessDenied, judge_match
+from search_cup.providers import (
+    FailingFakeProvider,
+    FakeProvider,
+    LiveProviderNotImplemented,
+    LockedLiveProvider,
+)
+from search_cup.runner import EntrantOutcome, MatchRun, run_match
+from search_cup.tools import (
+    BudgetedSearchProxy,
+    EntrantTools,
+    FakeSearchBackend,
+    FakeURLReader,
+    SearchBudgetExceeded,
+)
+
+
+def make_lead(url: str = "https://jobs.example.test/role") -> Lead:
+    return Lead(
+        company="Synthetic Employer",
+        role="AI Evaluation Engineer",
+        source_url=url,
+        official_source=True,
+        open_status="OPEN",
+        remote_scope="Europe Remote",
+        location_constraint="Spain eligible",
+        employment_type="Contract",
+        required_skills=("Python",),
+        candidate_fit="Relevant public evidence.",
+        mismatch_risks=(),
+        portfolio_relevance="Evaluation repository.",
+        confidence=0.9,
+        next_action="Human review.",
+        evidence_urls=(url,),
+        claimed_novel=True,
+    )
+
+
+class ContractTests(unittest.TestCase):
+    def test_candidate_fingerprint_is_order_independent(self) -> None:
+        document = dict(CandidateCard.load(DEFAULT_CANDIDATE).as_dict())
+        reversed_document = dict(reversed(tuple(document.items())))
+        self.assertEqual(
+            CandidateCard.from_mapping(document).fingerprint,
+            CandidateCard.from_mapping(reversed_document).fingerprint,
+        )
+
+    def test_candidate_rejects_private_fields(self) -> None:
+        document = dict(CandidateCard.load(DEFAULT_CANDIDATE).as_dict())
+        document["health"] = {"condition": "private"}
+        with self.assertRaisesRegex(ValueError, "private field"):
+            CandidateCard.from_mapping(document)
+
+    def test_candidate_uses_current_55_test_baseline(self) -> None:
+        content = CandidateCard.load(DEFAULT_CANDIDATE).canonical_content
+        self.assertIn("55/55", content)
+        self.assertNotIn("51/51", content)
+
+    def test_competition_freezes_four_exact_provider_identities(self) -> None:
+        spec = CompetitionSpec.load(DEFAULT_COMPETITION)
+        self.assertEqual(20, spec.max_search_calls)
+        self.assertFalse(spec.official_match_authorized)
+        self.assertEqual(
+            {"OpenAI", "Gemini", "DeepSeek", "GLM"},
+            {entrant.provider for entrant in spec.entrants},
+        )
+        self.assertTrue(all(entrant.exact_model_id for entrant in spec.entrants))
+
+    def test_submission_rejects_apply_now_outside_ranked_leads(self) -> None:
+        entrant = CompetitionSpec.load(DEFAULT_COMPETITION).entrants[0]
+        with self.assertRaisesRegex(ValueError, "Apply-Now"):
+            Submission(
+                entrant=entrant,
+                candidate_fingerprint="candidate",
+                competition_fingerprint="competition",
+                leads=(make_lead(),),
+                apply_now_urls=("https://jobs.example.test/other",),
+                search_strategy_summary="fixture",
+                rejected_or_downgraded=(),
+                uncertainties=(),
+                search_calls=1,
+            )
+
+    def test_frozen_submission_detects_tampering(self) -> None:
+        match, _, _ = build_offline_demo()
+        frozen = match.frozen_outcomes[0].frozen_submission
+        self.assertIsNotNone(frozen)
+        assert frozen is not None
+        frozen.thaw_verified()
+        tampered = FrozenSubmission(
+            entrant_id=frozen.entrant_id,
+            canonical_content=frozen.canonical_content + " ",
+            sha256=frozen.sha256,
+        )
+        with self.assertRaisesRegex(ValueError, "hash mismatch"):
+            tampered.thaw_verified()
+        with self.assertRaises(dataclasses.FrozenInstanceError):
+            frozen.sha256 = "replacement"  # type: ignore[misc]
+
+
+class ToolBoundaryTests(unittest.TestCase):
+    def test_call_21_is_physically_rejected(self) -> None:
+        backend_calls: list[str] = []
+
+        def backend(request):
+            backend_calls.append(request.query)
+            return ()
+
+        proxy = BudgetedSearchProxy("entrant", 20, backend)
+        for index in range(20):
+            proxy.search(f"query {index}")
+        with self.assertRaises(SearchBudgetExceeded):
+            proxy.search("query 21")
+        self.assertEqual(20, len(backend_calls))
+        self.assertEqual(20, proxy.calls_used)
+
+    def test_failed_backend_attempt_consumes_one_ticket(self) -> None:
+        def fail(_):
+            raise TimeoutError("offline injected failure")
+
+        proxy = BudgetedSearchProxy("entrant", 20, fail)
+        with self.assertRaises(TimeoutError):
+            proxy.search("query")
+        self.assertEqual(1, proxy.calls_used)
+        self.assertEqual("FAILED", proxy.traces[0].status)
+        self.assertEqual("TimeoutError", proxy.traces[0].error_type)
+
+    def test_url_reader_returns_typed_not_found_without_fallback(self) -> None:
+        result = FakeURLReader({}).read("https://example.test/missing")
+        self.assertEqual("NOT_FOUND", result.status)
+
+    def test_entrant_tool_surface_has_no_registry_access(self) -> None:
+        tools = EntrantTools(
+            BudgetedSearchProxy("entrant", 20, FakeSearchBackend({})),
+            FakeURLReader({}),
+        )
+        self.assertFalse(hasattr(tools, "registry"))
+        self.assertFalse(hasattr(tools, "judge_snapshot"))
+
+
+class RunnerAndJudgeTests(unittest.TestCase):
+    def test_four_entrant_offline_match_freezes_every_submission(self) -> None:
+        match, _, _ = build_offline_demo()
+        self.assertTrue(match.all_frozen)
+        self.assertEqual(4, len(match.frozen_outcomes))
+        self.assertEqual(0, len(match.failed_outcomes))
+        self.assertEqual({1}, {len(outcome.traces) for outcome in match.outcomes})
+        self.assertEqual(
+            {match.candidate_fingerprint},
+            {
+                outcome.frozen_submission.thaw_verified().candidate_fingerprint
+                for outcome in match.outcomes
+                if outcome.frozen_submission is not None
+            },
+        )
+
+    def test_one_provider_failure_preserves_other_frozen_evidence(self) -> None:
+        candidate = CandidateCard.load(DEFAULT_CANDIDATE)
+        spec = CompetitionSpec.load(DEFAULT_COMPETITION)
+        lead = make_lead()
+        providers = {
+            entrant.entrant_id: FakeProvider((), (lead,), (lead.source_url,))
+            for entrant in spec.entrants
+        }
+        providers[spec.entrants[1].entrant_id] = FailingFakeProvider()  # type: ignore[assignment]
+        match = run_match(
+            candidate,
+            spec,
+            providers,
+            search_fixtures=lambda _: {},
+            url_fixtures=lambda _: {},
+        )
+        self.assertEqual(3, len(match.frozen_outcomes))
+        self.assertEqual(1, len(match.failed_outcomes))
+        self.assertFalse(match.all_frozen)
+        for outcome in match.frozen_outcomes:
+            self.assertIsNotNone(outcome.frozen_submission)
+            outcome.frozen_submission.thaw_verified()  # type: ignore[union-attr]
+
+    def test_registry_refuses_access_before_execution_closes(self) -> None:
+        match, snapshot, _ = build_offline_demo()
+        open_match = MatchRun(
+            competition_id=match.competition_id,
+            candidate_fingerprint=match.candidate_fingerprint,
+            competition_fingerprint=match.competition_fingerprint,
+            expected_entrant_ids=match.expected_entrant_ids,
+            outcomes=match.outcomes,
+            entrant_execution_closed=False,
+        )
+        with self.assertRaisesRegex(RegistryAccessDenied, "still open"):
+            HiddenRegistryGate.open(open_match, snapshot)
+
+    def test_registry_refuses_partial_freeze(self) -> None:
+        match, snapshot, _ = build_offline_demo()
+        first = match.outcomes[0]
+        partial = MatchRun(
+            competition_id=match.competition_id,
+            candidate_fingerprint=match.candidate_fingerprint,
+            competition_fingerprint=match.competition_fingerprint,
+            expected_entrant_ids=match.expected_entrant_ids,
+            outcomes=(
+                first,
+                EntrantOutcome("missing", "FAILED", None, (), "Failure", "fixture"),
+            ),
+            entrant_execution_closed=True,
+        )
+        with self.assertRaisesRegex(RegistryAccessDenied, "must be frozen"):
+            HiddenRegistryGate.open(partial, snapshot)
+
+    def test_repeated_judging_is_byte_identical(self) -> None:
+        match, snapshot, report = build_offline_demo()
+        repeated = judge_match(match, snapshot)
+        self.assertEqual(report.report_fingerprint, repeated.report_fingerprint)
+        self.assertEqual(report.render_json(), repeated.render_json())
+        self.assertEqual(report.render_markdown(), repeated.render_markdown())
+
+    def test_registry_snapshot_hash_is_verified(self) -> None:
+        match, snapshot, _ = build_offline_demo()
+        tampered = dataclasses.replace(snapshot, fingerprint="0" * 64)
+        with self.assertRaisesRegex(ValueError, "snapshot hash mismatch"):
+            judge_match(match, tampered)
+
+    def test_apply_now_errors_receive_double_penalty(self) -> None:
+        match, snapshot, report = build_offline_demo()
+        deepseek = next(
+            score
+            for score in report.scores
+            if score.entrant_id == "deepseek-offline"
+        )
+        self.assertEqual(10.0, deepseek.penalties)
+        self.assertIn("closed/stale", deepseek.judgments[0].reasons[0])
+
+    def test_report_keeps_dimensions_and_exact_model_identity(self) -> None:
+        _, _, report = build_offline_demo()
+        document = json.loads(report.render_json())
+        self.assertEqual(4, len(document["scores"]))
+        self.assertTrue(
+            all(
+                item["exact_model_id"].startswith("fake-")
+                for item in document["scores"]
+            )
+        )
+        self.assertIn("search_efficiency", document["scores"][0])
+        self.assertIn("behavior", document["scores"][0])
+
+
+class CLIGateTests(unittest.TestCase):
+    def test_preflight_reports_offline_lock(self) -> None:
+        output = io.StringIO()
+        with redirect_stdout(output):
+            code = search_cup_main(["preflight"])
+        self.assertEqual(0, code)
+        result = json.loads(output.getvalue())
+        self.assertEqual("OFFLINE_ONLY", result["mode"])
+        self.assertFalse(result["official_match_authorized"])
+        self.assertEqual(0, result["live_provider_adapters"])
+
+    def test_live_provider_is_explicitly_unimplemented(self) -> None:
+        with self.assertRaisesRegex(LiveProviderNotImplemented, "outside ENG-SC-01-P0"):
+            LockedLiveProvider("OpenAI").run()
+
+    def test_p0_preflight_refuses_official_authorization(self) -> None:
+        document = json.loads(DEFAULT_COMPETITION.read_text(encoding="utf-8"))
+        document["official_match_authorized"] = True
+        with tempfile.TemporaryDirectory() as directory:
+            path = f"{directory}/authorized.json"
+            with open(path, "w", encoding="utf-8") as handle:
+                json.dump(document, handle)
+            with self.assertRaisesRegex(ValueError, "refuses"):
+                search_cup_main(["preflight", "--competition", path])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements the authorized **ENG-SC-01-P0** slice of #8 as an offline-only, zero-paid-call engineering harness.

## What changed

- immutable `CandidateCard`, `CompetitionSpec`, entrant, trace, submission, registry, and report contracts
- public-safe candidate card with canonical SHA-256 fingerprinting
- four exact fake-provider identities for deterministic P0 execution
- physically enforced 20-call search budget; failed attempts consume tickets and call 21 is rejected
- provider-isolated runner that preserves other frozen submissions after one entrant fails
- hidden-registry gate that opens only after execution closes and all four submissions are frozen
- deterministic rubric with doubled Apply-Now penalties and byte-identical repeated judging
- `llm-search-cup preflight` and `demo` commands only
- clean-wheel data packaging and Docker/Actions coverage

## Safety boundary

- **0 live provider adapters**
- **0 search/model API calls**
- no credential reads
- no official-match command
- `official_match_authorized: false`; P0 rejects an authorized spec
- no private corpus, private archive locator, or current drilling-table access
- no claim of official paid match results

## Validation

- existing evaluation suite: **32/32**
- new SEARCH-CUP P0 suite: **21/21**
- full suite: **53/53**
- clean non-editable wheel install + preflight: **PASS**
- privacy/credential/locator scan: **PASS**
- deterministic demo report fingerprint: `1a6eb993e33ca2ec493bafd243a768462d45e1c4a8bdc77b2c3c76f58f8f955b`
- local Docker: **NOT RUN** (engine unavailable); GitHub Actions clean build/container smoke is the remaining gate

## Frozen fingerprints

- CandidateCard: `ad9394a5eb6f0c795f84e4f32d03394105d27ee61b2a080717f8b9f1fc9df497`
- CompetitionSpec: `7877472af4d0909f117872f39c028f40b300d637f16120e311bed8b996e89743`

## Source correction before freeze

Issue #8's candidate card listed Companion-Mind as 51/51. Remote main currently verifies **55/55**, so the public-safe candidate contract freezes the current 55/55 fact instead of carrying the stale count forward.

This Draft PR does not close #8: live adapters, official paid execution, P4/P5 operations, and the final championship report remain separately gated.