### PR TITLE
ENG-SC-01 P1: add gated unified search_pro smoke

### DIFF
--- a/.github/workflows/p1-search-pro-smoke.yml
+++ b/.github/workflows/p1-search-pro-smoke.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   authorized-p1-smoke:
-    if: github.event.head_commit.message == 'ci: run authorized P1 search_pro smoke'
+    if: "\${{ github.event.head_commit.message == 'ci: run authorized P1 search_pro smoke v2' }}"
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:

--- a/.github/workflows/p1-search-pro-smoke.yml
+++ b/.github/workflows/p1-search-pro-smoke.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   authorized-p1-smoke:
-    if: "\${{ github.event.head_commit.message == 'ci: run authorized P1 search_pro smoke v2' }}"
+    if: "${{ github.event.head_commit.message == 'ci: run authorized P1 search_pro smoke v3' }}"
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:

--- a/.github/workflows/p1-search-pro-smoke.yml
+++ b/.github/workflows/p1-search-pro-smoke.yml
@@ -1,0 +1,141 @@
+name: P1 SearchPro Live Smoke
+
+on:
+  push:
+    branches:
+      - agent/search-cup-p1-search-pro-v0.1
+
+permissions:
+  contents: read
+
+jobs:
+  authorized-p1-smoke:
+    if: github.event.head_commit.message == 'ci: run authorized P1 search_pro smoke'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      GLM_API_KEY: ${{ secrets.GLM_API_KEY }}
+    steps:
+      - name: Check out authorized P1 branch
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install search-cup package without optional runtime dependencies
+        run: python -m pip install --no-deps .
+
+      - name: Verify secret injection without exposing its value
+        shell: bash
+        run: |
+          test -n "${GLM_API_KEY}"
+          echo "GLM_API_KEY=SET"
+
+      - name: Record P0/P1 preflight fingerprints
+        run: llm-search-cup preflight > p1-preflight.json
+
+      - name: Run exactly two authorized real search_pro calls
+        id: live_smoke
+        continue-on-error: true
+        run: |
+          llm-search-cup live-smoke \
+            --authorize-live-search-smoke \
+            --count 5 \
+            --timeout 30 \
+            --query "Python dataclasses documentation" \
+            --query "GitHub Actions workflow syntax" \
+            --output search-pro-smoke.json
+
+      - name: Validate content-safe P1 evidence
+        if: always()
+        shell: bash
+        run: |
+          python - <<'PY'
+          import hashlib
+          import json
+          import os
+          from pathlib import Path
+
+          preflight_path = Path("p1-preflight.json")
+          smoke_path = Path("search-pro-smoke.json")
+          assert preflight_path.is_file(), "preflight artifact missing"
+          assert smoke_path.is_file(), "live smoke artifact missing"
+
+          preflight = json.loads(preflight_path.read_text(encoding="utf-8"))
+          smoke = json.loads(smoke_path.read_text(encoding="utf-8"))
+
+          assert preflight["candidate_fingerprint"] == "ad9394a5eb6f0c795f84e4f32d03394105d27ee61b2a080717f8b9f1fc9df497"
+          assert preflight["competition_fingerprint"] == "7877472af4d0909f117872f39c028f40b300d637f16120e311bed8b996e89743"
+          assert preflight["official_match_authorized"] is False
+          assert preflight["live_provider_adapters"] == 0
+
+          assert smoke["phase"] == "ENG-SC-01-P1"
+          assert smoke["gate"] == "GREEN"
+          assert smoke["entrant_type"] == "Fake Entrant"
+          assert smoke["backend_id"] == "zhipu-web-search/search_pro"
+          assert smoke["calls_requested"] == 2
+          assert smoke["calls_used"] == 2
+          assert smoke["automatic_retries"] == 0
+          assert smoke["provider_adapters_invoked"] == 0
+          assert smoke["hidden_registry_loaded"] is False
+          assert smoke["official_match_authorized"] is False
+          assert smoke["credentials_logged"] is False
+          assert len(smoke["calls"]) == 2
+          assert len(smoke["traces"]) == 2
+          assert all(call["status"] == "SUCCEEDED" for call in smoke["calls"])
+          assert all(call["results"] for call in smoke["calls"])
+          assert [trace["call_number"] for trace in smoke["traces"]] == [1, 2]
+          assert all(trace["status"] == "SUCCEEDED" for trace in smoke["traces"])
+          assert all(trace["result_count"] > 0 for trace in smoke["traces"])
+          assert all(trace["backend_id"] == "zhipu-web-search/search_pro" for trace in smoke["traces"])
+          assert all(trace["backend_attempts"] == 1 for trace in smoke["traces"])
+          assert all(trace["automatic_retries"] == 0 for trace in smoke["traces"])
+
+          serialized = json.dumps(smoke, ensure_ascii=False, sort_keys=True)
+          secret = os.environ["GLM_API_KEY"]
+          assert secret not in serialized, "credential leaked into evidence"
+
+          evidence = {
+              "authorization": "Issue #8 / PR #10: exactly two non-official Fake Entrant calls",
+              "commit_sha": os.environ["GITHUB_SHA"],
+              "preflight": preflight,
+              "smoke": smoke,
+              "smoke_sha256": hashlib.sha256(smoke_path.read_bytes()).hexdigest(),
+          }
+          evidence_path = Path("p1-search-pro-evidence.json")
+          evidence_path.write_text(
+              json.dumps(evidence, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+              encoding="utf-8",
+          )
+
+          summary = Path(os.environ["GITHUB_STEP_SUMMARY"])
+          with summary.open("a", encoding="utf-8") as handle:
+              handle.write("## ENG-SC-01-P1 SearchProxy live smoke\n\n")
+              handle.write("- Gate: **GREEN**\n")
+              handle.write("- Backend: `zhipu-web-search/search_pro`\n")
+              handle.write("- Fake Entrant calls: **2/2**\n")
+              handle.write("- Normalized results: **{} + {}**\n".format(
+                  smoke["traces"][0]["result_count"],
+                  smoke["traces"][1]["result_count"],
+              ))
+              handle.write("- Automatic retries: **0**\n")
+              handle.write("- Provider adapters: **0**\n")
+              handle.write("- Hidden registry loaded: **false**\n")
+              handle.write("- Official match authorized: **false**\n")
+              handle.write("- Credentials logged: **false**\n")
+          print("P1_SEARCH_PRO_SMOKE=GREEN")
+          PY
+
+      - name: Upload immutable P1 smoke evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: eng-sc-01-p1-search-pro-smoke
+          path: |
+            p1-preflight.json
+            search-pro-smoke.json
+            p1-search-pro-evidence.json
+          if-no-files-found: warn
+          retention-days: 30

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
         working-directory: llm-evaluation-lab
         run: python -m unittest discover -s tests -v
 
-      - name: Run SEARCH-CUP-02 P0 offline gate
+      - name: Run SEARCH-CUP-02 P0 regression and P1 offline gates
         working-directory: llm-evaluation-lab
         run: |
           llm-search-cup preflight > /tmp/search-cup-preflight.json
@@ -61,6 +61,8 @@ jobs:
           assert preflight['mode'] == 'OFFLINE_ONLY'
           assert preflight['official_match_authorized'] is False
           assert preflight['live_provider_adapters'] == 0
+          assert preflight['search_pro_backend_available'] is True
+          assert preflight['live_search_requires_explicit_smoke_authorization'] is True
           assert preflight['entrant_count'] == 4
           assert len(report['scores']) == 4
           assert all(score['exact_model_id'].startswith('fake-') for score in report['scores'])
@@ -156,7 +158,7 @@ jobs:
 
           docker run --rm llm-evaluation-lab:ci --version \
             > /tmp/docker-version.txt
-          grep --quiet '^llm-eval 0.8.0$' /tmp/docker-version.txt
+          grep --quiet '^llm-eval 0.9.0$' /tmp/docker-version.txt
 
           docker run --rm \
             --entrypoint llm-search-cup \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG COMPANION_MIND_COMMIT=c6a2128271532746a5570b99ce0ccdea4618db4e
 
 LABEL org.opencontainers.image.source="https://github.com/aerenkolstein-code/llm-evaluation-lab" \
       org.opencontainers.image.description="Reproducible public-safe LLM evaluation harness" \
-      org.opencontainers.image.version="0.8.0"
+      org.opencontainers.image.version="0.9.0"
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@
 | Evaluation tests | 32/32 |
 | Container CLI/API smoke | PASS |
 | Executable MitigationSpec | Runtime-validated |
-| SEARCH-CUP-02 P0 offline tests | 21/21 |
-| Full repository tests | 53/53 |
+| SEARCH-CUP-02 P0/P1 tests | 27/27 |
+| Full repository tests | 59/59 |
 
 **Status:** Experimental / reproducible artifact  
 **Evidence level:** E3 — reproducible public-safe evaluation
@@ -140,9 +140,9 @@ to commit `c6a2128271532746a5570b99ce0ccdea4618db4e`, installs the evaluation
 package, and runs as an unprivileged user.
 
 ```bash
-docker build -t llm-evaluation-lab:0.8 .
+docker build -t llm-evaluation-lab:0.9 .
 
-docker run --rm llm-evaluation-lab:0.8 \
+docker run --rm llm-evaluation-lab:0.9 \
   --suite historical \
   --cases cases/anonymized/premature-parent-closure.md
 ```
@@ -155,21 +155,21 @@ docker run --rm \
   -p 127.0.0.1:8000:8000 \
   -v /absolute/path/to/data:/data:ro \
   --entrypoint llm-eval-api \
-  llm-evaluation-lab:0.8 \
+  llm-evaluation-lab:0.9 \
   --store /data/eval-runs.sqlite3 \
   --host 0.0.0.0 \
   --allow-network
 ```
 
-CI builds the image from a clean checkout, verifies version `0.8.0`, executes the
+CI builds the image from a clean checkout, verifies version `0.9.0`, executes the
 24-case historical regression, creates a mounted SQLite record, then queries the
 containerized API over HTTP. This is reproducible local packaging, not a published
 registry image or production deployment.
 
-## SEARCH-CUP-02 Offline Fairness Harness v0.8
+## SEARCH-CUP-02 Unified SearchProxy v0.9
 
-`ENG-SC-01-P0` adds a closed-book, provider-neutral search-benchmark skeleton.
-It is intentionally offline: four deterministic fake entrants receive the same
+`ENG-SC-01-P0` added a closed-book, provider-neutral search-benchmark skeleton.
+The P0 regression remains intentionally offline: four deterministic fake entrants receive the same
 canonical Candidate Card and CompetitionSpec; each gets an isolated search tool
 with a hard 20-call budget; submissions are frozen and SHA-256 hashed before a
 synthetic hidden registry can be opened; the judge then produces a deterministic
@@ -180,10 +180,30 @@ llm-search-cup preflight
 llm-search-cup demo --format markdown
 ```
 
-The P0 CLI contains no live provider adapter, real search backend, credential
-path, or official-match command. It cannot spend model/search quota or run the
-authorized-but-not-approved 80-search-call match. The included employers, URLs,
-registry, and scores are synthetic fixtures and are not job leads.
+`ENG-SC-01-P1` adds exactly one live infrastructure boundary: Zhipu Web Search
+API with `search_engine=search_pro`. It normalizes official `title`, `link`, and
+`content` fields into the same `SearchResult` contract used by every future
+provider adapter. The backend performs no automatic retry: a caller retry is a
+new SearchProxy call and therefore a new budget event.
+
+The only live command is a manually gated Fake Entrant smoke with one to three
+queries:
+
+```bash
+export GLM_API_KEY=...  # keep this outside shell history and repository files
+llm-search-cup live-smoke \
+  --authorize-live-search-smoke \
+  --query 'OpenAI careers evaluation remote Europe' \
+  --query 'Anthropic careers model behavior remote Europe' \
+  --output /tmp/search-pro-smoke.json
+```
+
+The command has no model adapter, Candidate Card handoff, hidden-registry handle,
+judge, provider loop, or official-match path. It cannot turn two smoke queries
+into the four-model 80-call match. The API key is read only from the named
+environment variable and is never included in results, errors, traces, or Git.
+Without the explicit authorization flag, the command fails before key lookup or
+network access.
 
 P0 evidence:
 
@@ -194,6 +214,20 @@ P0 evidence:
 - hidden-registry access fails until all four submissions are frozen and entrant execution is closed;
 - repeated judging is byte-identical and requires no model call;
 - Apply-Now errors receive the specified 2× penalty.
+
+P1 evidence:
+
+- one `search_web` invocation creates one trace and consumes one ticket whether
+  the backend succeeds, returns HTTP 429, violates its schema, or rejects an
+  invalid query;
+- traces record entrant, query, call number, normalized result count, backend and
+  request identity, HTTP/error fields, duration, and an explicit zero automatic
+  retry count;
+- the 21st call remains rejected before any backend execution;
+- P0 hidden-registry isolation, provider failure isolation, freeze/hash, and
+  deterministic judging remain green;
+- all four future provider adapters will receive the same `EntrantTools.search_web`
+  and `SearchResult` contract; P1 implements zero real model adapters.
 
 ## Executable integration v0.3
 
@@ -253,7 +287,7 @@ boundary explicit: Eval Lab specifies and verifies; Companion-Mind implements.
 ## Artifact map
 
 - `evaluation_lab.py` — loader, policies, grader, metrics, regression gate, CLI, and read-only API
-- `search_cup/` — P0 contracts, budgeted tools, fake providers, isolated runner, hidden judge, and offline CLI
+- `search_cup/` — P0 contracts plus the gated P1 `search_pro` backend, budgeted tools, fake providers, isolated runner, hidden judge, and CLI
 - `candidates/` and `competitions/` — canonical public-safe P0 inputs and fingerprints
 - `cases/anonymized/premature-parent-closure.md` — first-loop case card plus executable 24-case historical benchmark
 - `experiments/closure-guard-mitigation.md` — mitigation, decision rule, and executable JSON contract
@@ -264,10 +298,11 @@ boundary explicit: Eval Lab specifies and verifies; Companion-Mind implements.
 
 ## Roadmap
 
-**SEARCH-CUP-02 P0 complete; live phases locked** — the fully offline fairness
-harness is implemented. SearchProxy integration, live provider adapters, immutable
-SQLite match evidence, the private judge snapshot, and any paid official match
-remain separate gated phases under Issue #8.
+**SEARCH-CUP-02 P1 implemented; provider phases locked** — the offline fairness
+harness and unified real-search boundary are implemented. OpenAI, Gemini,
+DeepSeek, and GLM model adapters, immutable match evidence, the private judge
+snapshot, and any official 80-call match remain separate gated phases under
+Issue #8.
 
 ## Privacy
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -29,7 +29,7 @@ companion-mind validate-mitigation --mitigation-spec /tmp/mitigation.json
 
 `llm-eval` 现在负责校验并输出完整的 `mitigation-spec/v1`，再用它实例化 Companion-Mind 的真实 `ClosureGuard`。报告同时记录 runtime 实际加载的 mitigation ID、safeguard ID、schema version 与 canonical SHA-256 fingerprint，从而证明“写入评测报告的配置”与“运行时真正执行的配置”一致。
 
-原有评测主线仍保持 **32/32 tests**；加上 SEARCH-CUP-02 P0 的 **21/21** 项，当前全仓为 **53/53**。
+原有评测主线仍保持 **32/32 tests**；SEARCH-CUP-02 P0/P1 为 **27/27**，当前全仓为 **59/59**。
 
 ## Historical Failure Benchmark v0.4
 
@@ -63,17 +63,17 @@ llm-eval \
 `c6a2128271532746a5570b99ce0ccdea4618db4e`，容器以非 root 用户运行。
 
 ```bash
-docker build -t llm-evaluation-lab:0.8 .
-docker run --rm llm-evaluation-lab:0.8 \
+docker build -t llm-evaluation-lab:0.9 .
+docker run --rm llm-evaluation-lab:0.9 \
   --suite historical \
   --cases cases/anonymized/premature-parent-closure.md
 ```
 
-GitHub Actions 会从 clean checkout 构建镜像、核验 `0.8.0`、复跑 24 案例历史基准、
+GitHub Actions 会从 clean checkout 构建镜像、核验 `0.9.0`、复跑 24 案例历史基准、
 在挂载目录中生成 SQLite 记录，并通过真实 HTTP 查询容器化 API。它证明本地容器复跑能力，
 不代表已经发布 registry image、完成云部署或达到生产可靠性。
 
-## SEARCH-CUP-02 离线公平性框架 v0.8
+## SEARCH-CUP-02 统一 SearchProxy v0.9
 
 `ENG-SC-01-P0` 已实现四名 Fake Entrant 的封闭式离线比赛：四方读取字节一致的
 Candidate Card 与 CompetitionSpec；每方拥有独立的 20 次搜索硬预算；Submission
@@ -85,7 +85,24 @@ llm-search-cup preflight
 llm-search-cup demo --format markdown
 ```
 
-P0 中没有 live provider adapter、真实搜索后端、密钥读取路径或正式比赛命令，不能触发
-四模型 80 次搜索。示例公司、网址、隐藏井表与分数全部是离线合成夹具，不是真实岗位。
+P0 的离线公平性回归全部保留。P1 只新增一个真实基础设施边界：智谱 Web Search API，
+固定 `search_engine=search_pro`，并将 `title/link/content` 标准化成未来四个 Provider 共用的
+`SearchResult`。一次 `search_web` 调用严格记一次券；成功、HTTP 失败、协议失败和非法查询
+都写入可审计 trace；没有隐式自动重试。
+
+唯一 live 入口是手动授权的 Fake Entrant smoke，最多 3 个 query：
+
+```bash
+export GLM_API_KEY=...
+llm-search-cup live-smoke \
+  --authorize-live-search-smoke \
+  --query 'OpenAI careers evaluation remote Europe' \
+  --query 'Anthropic careers model behavior remote Europe' \
+  --output /tmp/search-pro-smoke.json
+```
+
+该命令不会调用 OpenAI / Gemini / DeepSeek / GLM 模型，不会加载 Candidate Card、隐藏井表或
+Judge，也没有正式比赛循环。密钥只从环境变量读取，不进入结果、错误、trace 或 Git；缺少
+显式授权 flag 时，在读取密钥和联网前即拒绝。四模型 80 发仍需董事会另行授权。
 
 第三仓仍保留 concept growth、prior lock-in、world-model drift、longitudinal evolution 与 experimental timeline；failure taxonomy 只是公开接口，不取代纵向评估内核。

--- a/evaluation_lab.py
+++ b/evaluation_lab.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from typing import Any, Callable, Iterable, Mapping, Sequence
 
 
-__version__ = "0.8.0"
+__version__ = "0.9.0"
 
 Child = Mapping[str, str]
 Case = Mapping[str, object]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "llm-evaluation-lab"
-version = "0.8.0"
-description = "Reproducible LLM evaluation harness with an offline closed-book search benchmark"
+version = "0.9.0"
+description = "Reproducible LLM evaluation harness with a gated provider-neutral search benchmark"
 requires-python = ">=3.11"
 dependencies = [
   "fastapi>=0.115,<1",

--- a/search_cup/__init__.py
+++ b/search_cup/__init__.py
@@ -12,6 +12,7 @@ from .contracts import (
 )
 from .judge import CompetitionReport, HiddenRegistryGate, judge_match
 from .runner import MatchRun, run_match
+from .search_pro import SearchProBackend
 
 __all__ = [
     "CandidateCard",
@@ -25,6 +26,7 @@ __all__ = [
     "MatchRun",
     "RegistryLeadAssessment",
     "Submission",
+    "SearchProBackend",
     "judge_match",
     "run_match",
 ]

--- a/search_cup/cli.py
+++ b/search_cup/cli.py
@@ -1,4 +1,4 @@
-"""P0-only CLI. It intentionally exposes no paid/live match command."""
+"""P0/P1 CLI with an explicitly authorized search-only live smoke."""
 
 from __future__ import annotations
 
@@ -9,6 +9,7 @@ from typing import Sequence
 
 from .contracts import CandidateCard, CompetitionSpec
 from .demo import DEFAULT_CANDIDATE, DEFAULT_COMPETITION, build_offline_demo
+from .search_pro import run_live_smoke
 
 
 def _parser() -> argparse.ArgumentParser:
@@ -24,6 +25,21 @@ def _parser() -> argparse.ArgumentParser:
     demo.add_argument("--competition", default=str(DEFAULT_COMPETITION))
     demo.add_argument("--format", choices=("json", "markdown"), default="json")
     demo.add_argument("--output")
+
+    live_smoke = subcommands.add_parser(
+        "live-smoke",
+        help="run 1-3 Fake Entrant queries through real search_pro; no model calls",
+    )
+    live_smoke.add_argument("--query", action="append", required=True)
+    live_smoke.add_argument("--count", type=int, default=5)
+    live_smoke.add_argument("--timeout", type=float, default=30.0)
+    live_smoke.add_argument("--api-key-env", default="GLM_API_KEY")
+    live_smoke.add_argument("--output")
+    live_smoke.add_argument(
+        "--authorize-live-search-smoke",
+        action="store_true",
+        help="required manual gate; authorizes only these 1-3 search calls",
+    )
     return parser
 
 
@@ -35,7 +51,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         if competition.official_match_authorized:
             raise ValueError("P0 preflight refuses an authorized official-match spec")
         result = {
-            "phase": "ENG-SC-01-P0",
+            "phase": "ENG-SC-01-P1",
             "mode": "OFFLINE_ONLY",
             "candidate_fingerprint": candidate.fingerprint,
             "competition_fingerprint": competition.fingerprint,
@@ -43,9 +59,30 @@ def main(argv: Sequence[str] | None = None) -> int:
             "search_budget_per_entrant": competition.max_search_calls,
             "official_match_authorized": competition.official_match_authorized,
             "live_provider_adapters": 0,
+            "search_pro_backend_available": True,
+            "live_search_requires_explicit_smoke_authorization": True,
         }
         print(json.dumps(result, indent=2, sort_keys=True))
         return 0
+
+    if args.command == "live-smoke":
+        if not args.authorize_live_search_smoke:
+            raise ValueError(
+                "live-smoke requires --authorize-live-search-smoke; "
+                "this does not authorize provider adapters or the official match"
+            )
+        artifact, green = run_live_smoke(
+            args.query,
+            api_key_env=args.api_key_env,
+            count=args.count,
+            timeout_seconds=args.timeout,
+        )
+        rendered = json.dumps(artifact, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+        if args.output:
+            Path(args.output).write_text(rendered, encoding="utf-8")
+        else:
+            print(rendered, end="")
+        return 0 if green else 1
 
     _, _, report = build_offline_demo(args.candidate, args.competition)
     rendered = report.render_json() if args.format == "json" else report.render_markdown()

--- a/search_cup/contracts.py
+++ b/search_cup/contracts.py
@@ -221,10 +221,16 @@ class CompetitionSpec:
 class SearchRequest:
     entrant_id: str
     query: str
+    call_number: int = 0
+    request_id: str = ""
 
     def __post_init__(self) -> None:
         _required_text(self.entrant_id, "entrant_id")
         _required_text(self.query, "query")
+        if self.call_number < 0:
+            raise ValueError("call_number must not be negative")
+        if self.request_id:
+            _required_text(self.request_id, "request_id")
 
 
 @dataclass(frozen=True)
@@ -246,6 +252,17 @@ class SearchTrace:
     status: str
     result_count: int
     error_type: str | None = None
+    error_code: str | None = None
+    error_message: str | None = None
+    backend_id: str | None = None
+    backend_request_id: str | None = None
+    backend_response_id: str | None = None
+    http_status: int | None = None
+    retryable: bool | None = None
+    backend_attempts: int = 1
+    automatic_retries: int = 0
+    started_at_utc: str | None = None
+    duration_ms: float | None = None
 
 
 @dataclass(frozen=True)

--- a/search_cup/search_pro.py
+++ b/search_cup/search_pro.py
@@ -1,0 +1,316 @@
+"""Narrow P1 adapter for Zhipu's real ``search_pro`` Web Search API."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict, dataclass
+from typing import Callable, Mapping, Sequence
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+from uuid import uuid4
+
+from .contracts import SearchRequest, SearchResult
+from .tools import (
+    BudgetedSearchProxy,
+    EntrantTools,
+    FakeURLReader,
+    SearchBackendError,
+    SearchBackendResponse,
+)
+
+
+SEARCH_PRO_BACKEND_ID = "zhipu-web-search/search_pro"
+SEARCH_PRO_ENDPOINT = "https://open.bigmodel.cn/api/paas/v4/web_search"
+
+
+@dataclass(frozen=True)
+class TransportResponse:
+    status_code: int
+    body: bytes
+
+
+SearchTransport = Callable[
+    [str, Mapping[str, str], Mapping[str, object], float], TransportResponse
+]
+
+
+def _default_transport(
+    endpoint: str,
+    headers: Mapping[str, str],
+    payload: Mapping[str, object],
+    timeout_seconds: float,
+) -> TransportResponse:
+    request = Request(
+        endpoint,
+        data=json.dumps(payload, ensure_ascii=False).encode("utf-8"),
+        headers=dict(headers),
+        method="POST",
+    )
+    try:
+        with urlopen(request, timeout=timeout_seconds) as response:
+            return TransportResponse(
+                status_code=int(response.status),
+                body=response.read(),
+            )
+    except HTTPError as exc:
+        return TransportResponse(status_code=int(exc.code), body=exc.read())
+    except (URLError, TimeoutError, OSError) as exc:
+        raise SearchBackendError(
+            f"search_pro network request failed: {type(exc).__name__}",
+            backend_id=SEARCH_PRO_BACKEND_ID,
+            error_code="NETWORK_ERROR",
+            retryable=True,
+        ) from exc
+
+
+def _text(value: object) -> str:
+    return value.strip() if isinstance(value, str) else ""
+
+
+def _decode_json(body: bytes, request_id: str) -> Mapping[str, object]:
+    try:
+        document = json.loads(body.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise SearchBackendError(
+            "search_pro returned invalid JSON",
+            backend_id=SEARCH_PRO_BACKEND_ID,
+            error_code="INVALID_JSON",
+            request_id=request_id,
+        ) from exc
+    if not isinstance(document, Mapping):
+        raise SearchBackendError(
+            "search_pro returned a non-object response",
+            backend_id=SEARCH_PRO_BACKEND_ID,
+            error_code="INVALID_RESPONSE",
+            request_id=request_id,
+        )
+    return document
+
+
+def _error_details(document: Mapping[str, object]) -> tuple[str, str]:
+    error = document.get("error")
+    if not isinstance(error, Mapping):
+        return "HTTP_ERROR", "search_pro request failed"
+    code = _text(error.get("code")) or "API_ERROR"
+    message = _text(error.get("message")) or "search_pro request failed"
+    return code, message[:500]
+
+
+class SearchProBackend:
+    """One SearchRequest becomes exactly one HTTP request; no hidden retries."""
+
+    backend_id = SEARCH_PRO_BACKEND_ID
+
+    def __init__(
+        self,
+        api_key: str,
+        *,
+        count: int = 10,
+        timeout_seconds: float = 30.0,
+        endpoint: str = SEARCH_PRO_ENDPOINT,
+        transport: SearchTransport = _default_transport,
+    ) -> None:
+        if not api_key.strip():
+            raise ValueError("search_pro API key must not be empty")
+        if not 1 <= count <= 50:
+            raise ValueError("search_pro count must be between 1 and 50")
+        if timeout_seconds <= 0:
+            raise ValueError("timeout_seconds must be positive")
+        self._api_key = api_key.strip()
+        self._count = count
+        self._timeout_seconds = timeout_seconds
+        self._endpoint = endpoint
+        self._transport = transport
+
+    @classmethod
+    def from_env(
+        cls,
+        env_name: str = "GLM_API_KEY",
+        **kwargs: object,
+    ) -> "SearchProBackend":
+        api_key = os.environ.get(env_name, "")
+        if not api_key.strip():
+            raise RuntimeError(f"required API key environment variable is not set: {env_name}")
+        return cls(api_key, **kwargs)
+
+    def __call__(self, request: SearchRequest) -> SearchBackendResponse:
+        request_id = request.request_id or f"sc-{uuid4().hex}"
+        if len(request.query) > 70:
+            raise SearchBackendError(
+                "search_pro query exceeds the 70-character API limit",
+                backend_id=self.backend_id,
+                error_code="INVALID_QUERY",
+                request_id=request_id,
+            )
+        payload = {
+            "search_query": request.query,
+            "search_engine": "search_pro",
+            "search_intent": False,
+            "count": self._count,
+            "search_recency_filter": "noLimit",
+            "content_size": "medium",
+            "request_id": request_id,
+        }
+        response = self._transport(
+            self._endpoint,
+            {
+                "Authorization": f"Bearer {self._api_key}",
+                "Content-Type": "application/json",
+            },
+            payload,
+            self._timeout_seconds,
+        )
+        if not 200 <= response.status_code < 300:
+            try:
+                document = _decode_json(response.body, request_id)
+            except SearchBackendError as exc:
+                raise SearchBackendError(
+                    f"search_pro HTTP {response.status_code} returned no valid error object",
+                    backend_id=self.backend_id,
+                    error_code=f"HTTP_{response.status_code}",
+                    request_id=request_id,
+                    http_status=response.status_code,
+                    retryable=response.status_code in {408, 429, 500, 502, 503, 504},
+                ) from exc
+            response_request_id = _text(document.get("request_id")) or request_id
+            response_id = _text(document.get("id")) or None
+            code, message = _error_details(document)
+            raise SearchBackendError(
+                f"search_pro request failed: {code}: {message}",
+                backend_id=self.backend_id,
+                error_code=code,
+                request_id=response_request_id,
+                response_id=response_id,
+                http_status=response.status_code,
+                retryable=response.status_code in {408, 429, 500, 502, 503, 504},
+            )
+        document = _decode_json(response.body, request_id)
+        response_request_id = _text(document.get("request_id")) or request_id
+        response_id = _text(document.get("id")) or None
+        if "error" in document:
+            code, message = _error_details(document)
+            raise SearchBackendError(
+                f"search_pro request failed: {code}: {message}",
+                backend_id=self.backend_id,
+                error_code=code,
+                request_id=response_request_id,
+                response_id=response_id,
+                http_status=response.status_code,
+                retryable=False,
+            )
+        raw_results = document.get("search_result")
+        if not isinstance(raw_results, list):
+            raise SearchBackendError(
+                "search_pro response is missing search_result[]",
+                backend_id=self.backend_id,
+                error_code="INVALID_RESPONSE",
+                request_id=response_request_id,
+                response_id=response_id,
+                http_status=response.status_code,
+            )
+        normalized: list[SearchResult] = []
+        for index, item in enumerate(raw_results):
+            if not isinstance(item, Mapping):
+                raise SearchBackendError(
+                    f"search_pro result {index} is not an object",
+                    backend_id=self.backend_id,
+                    error_code="INVALID_RESULT",
+                    request_id=response_request_id,
+                    response_id=response_id,
+                    http_status=response.status_code,
+                )
+            title = _text(item.get("title"))
+            url = _text(item.get("link"))
+            if not title or not url:
+                raise SearchBackendError(
+                    f"search_pro result {index} is missing title or link",
+                    backend_id=self.backend_id,
+                    error_code="INVALID_RESULT",
+                    request_id=response_request_id,
+                    response_id=response_id,
+                    http_status=response.status_code,
+                )
+            normalized.append(
+                SearchResult(
+                    title=title,
+                    url=url,
+                    snippet=_text(item.get("content")),
+                )
+            )
+        return SearchBackendResponse(
+            results=tuple(normalized),
+            backend_id=self.backend_id,
+            request_id=response_request_id,
+            response_id=response_id,
+        )
+
+
+def run_live_smoke(
+    queries: Sequence[str],
+    *,
+    api_key_env: str = "GLM_API_KEY",
+    count: int = 5,
+    timeout_seconds: float = 30.0,
+) -> tuple[dict[str, object], bool]:
+    """Run at most three non-official Fake Entrant queries through the real backend."""
+
+    normalized_queries = tuple(query.strip() for query in queries if query.strip())
+    if not 1 <= len(normalized_queries) <= 3:
+        raise ValueError("P1 live smoke requires between one and three non-empty queries")
+    backend = SearchProBackend.from_env(
+        api_key_env,
+        count=count,
+        timeout_seconds=timeout_seconds,
+    )
+    proxy = BudgetedSearchProxy(
+        entrant_id="fake-search-pro-smoke",
+        max_calls=20,
+        backend=backend,
+    )
+    tools = EntrantTools(search_proxy=proxy, url_reader=FakeURLReader({}))
+    calls: list[dict[str, object]] = []
+    smoke_green = True
+    for query in normalized_queries:
+        try:
+            results = tools.search_web(query)
+            if not results:
+                smoke_green = False
+            calls.append(
+                {
+                    "query": query,
+                    "status": "SUCCEEDED",
+                    "results": [asdict(item) for item in results],
+                }
+            )
+            if not results:
+                break
+        except SearchBackendError as exc:
+            smoke_green = False
+            calls.append(
+                {
+                    "query": query,
+                    "status": "FAILED",
+                    "error_type": type(exc).__name__,
+                    "error_code": exc.error_code,
+                    "error_message": str(exc),
+                }
+            )
+            break
+    artifact = {
+        "phase": "ENG-SC-01-P1",
+        "gate": "GREEN" if smoke_green else "RED",
+        "entrant_type": "Fake Entrant",
+        "backend_id": SEARCH_PRO_BACKEND_ID,
+        "search_budget": 20,
+        "calls_requested": len(normalized_queries),
+        "calls_used": tools.search_calls,
+        "automatic_retries": 0,
+        "official_match_authorized": False,
+        "provider_adapters_invoked": 0,
+        "hidden_registry_loaded": False,
+        "credentials_logged": False,
+        "calls": calls,
+        "traces": [asdict(trace) for trace in tools.traces],
+    }
+    return artifact, smoke_green

--- a/search_cup/tools.py
+++ b/search_cup/tools.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime, timezone
+from time import perf_counter
 from typing import Callable, Mapping, Sequence
+from uuid import uuid4
 
 from .contracts import SearchRequest, SearchResult, SearchTrace, URLReadResult
 
@@ -12,7 +15,42 @@ class SearchBudgetExceeded(RuntimeError):
     """Raised before any backend call when an entrant has spent all tickets."""
 
 
-SearchBackend = Callable[[SearchRequest], Sequence[SearchResult]]
+class SearchBackendError(RuntimeError):
+    """Typed, credential-free failure surfaced by a live search backend."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        backend_id: str,
+        error_code: str,
+        request_id: str | None = None,
+        response_id: str | None = None,
+        http_status: int | None = None,
+        retryable: bool = False,
+    ) -> None:
+        super().__init__(message)
+        self.backend_id = backend_id
+        self.error_code = error_code
+        self.request_id = request_id
+        self.response_id = response_id
+        self.http_status = http_status
+        self.retryable = retryable
+
+
+@dataclass(frozen=True)
+class SearchBackendResponse:
+    """Provider response normalized before it crosses the SearchProxy boundary."""
+
+    results: tuple[SearchResult, ...]
+    backend_id: str
+    request_id: str
+    response_id: str | None = None
+
+
+SearchBackend = Callable[
+    [SearchRequest], SearchBackendResponse | Sequence[SearchResult]
+]
 
 
 class BudgetedSearchProxy:
@@ -45,11 +83,32 @@ class BudgetedSearchProxy:
                 f"{self._entrant_id}: search call {self.calls_used + 1} rejected; "
                 f"budget is {self._max_calls}"
             )
-        request = SearchRequest(entrant_id=self._entrant_id, query=query)
         call_number = self.calls_used + 1
+        request_id = f"sc-{uuid4().hex}"
+        started_at = datetime.now(timezone.utc).isoformat()
+        started_clock = perf_counter()
+        backend_id = getattr(self._backend, "backend_id", type(self._backend).__name__)
         try:
-            results = tuple(self._backend(request))
-        except Exception as exc:
+            request = SearchRequest(
+                entrant_id=self._entrant_id,
+                query=query,
+                call_number=call_number,
+                request_id=request_id,
+            )
+            raw_response = self._backend(request)
+            if isinstance(raw_response, SearchBackendResponse):
+                results = raw_response.results
+                backend_id = raw_response.backend_id
+                backend_request_id = raw_response.request_id
+                backend_response_id = raw_response.response_id
+            else:
+                results = tuple(raw_response)
+                backend_request_id = request_id
+                backend_response_id = None
+            if not all(isinstance(item, SearchResult) for item in results):
+                raise TypeError("search backend returned a non-SearchResult item")
+        except SearchBackendError as exc:
+            duration_ms = round((perf_counter() - started_clock) * 1000, 3)
             self._traces.append(
                 SearchTrace(
                     entrant_id=self._entrant_id,
@@ -58,9 +117,39 @@ class BudgetedSearchProxy:
                     status="FAILED",
                     result_count=0,
                     error_type=type(exc).__name__,
+                    error_code=exc.error_code,
+                    error_message=str(exc),
+                    backend_id=exc.backend_id,
+                    backend_request_id=exc.request_id or request_id,
+                    backend_response_id=exc.response_id,
+                    http_status=exc.http_status,
+                    retryable=exc.retryable,
+                    started_at_utc=started_at,
+                    duration_ms=duration_ms,
                 )
             )
             raise
+        except Exception as exc:
+            duration_ms = round((perf_counter() - started_clock) * 1000, 3)
+            self._traces.append(
+                SearchTrace(
+                    entrant_id=self._entrant_id,
+                    call_number=call_number,
+                    query=query,
+                    status="FAILED",
+                    result_count=0,
+                    error_type=type(exc).__name__,
+                    error_code="UNEXPECTED_BACKEND_ERROR",
+                    error_message=str(exc),
+                    backend_id=str(backend_id),
+                    backend_request_id=request_id,
+                    retryable=False,
+                    started_at_utc=started_at,
+                    duration_ms=duration_ms,
+                )
+            )
+            raise
+        duration_ms = round((perf_counter() - started_clock) * 1000, 3)
         self._traces.append(
             SearchTrace(
                 entrant_id=self._entrant_id,
@@ -68,15 +157,23 @@ class BudgetedSearchProxy:
                 query=query,
                 status="SUCCEEDED",
                 result_count=len(results),
+                backend_id=str(backend_id),
+                backend_request_id=backend_request_id,
+                backend_response_id=backend_response_id,
+                http_status=200,
+                retryable=False,
+                started_at_utc=started_at,
+                duration_ms=duration_ms,
             )
         )
-        return results
+        return tuple(results)
 
 
 class FakeSearchBackend:
     """Offline backend whose complete result set is supplied by a fixture."""
 
     def __init__(self, results_by_query: Mapping[str, Sequence[SearchResult]]) -> None:
+        self.backend_id = "fake-search-pro-offline"
         self._results = {
             query: tuple(results) for query, results in results_by_query.items()
         }

--- a/tests/test_search_cup.py
+++ b/tests/test_search_cup.py
@@ -34,11 +34,13 @@ from search_cup.providers import (
     LockedLiveProvider,
 )
 from search_cup.runner import EntrantOutcome, MatchRun, run_match
+from search_cup.search_pro import SearchProBackend, TransportResponse
 from search_cup.tools import (
     BudgetedSearchProxy,
     EntrantTools,
     FakeSearchBackend,
     FakeURLReader,
+    SearchBackendError,
     SearchBudgetExceeded,
 )
 
@@ -153,6 +155,22 @@ class ToolBoundaryTests(unittest.TestCase):
         self.assertEqual("FAILED", proxy.traces[0].status)
         self.assertEqual("TimeoutError", proxy.traces[0].error_type)
 
+    def test_invalid_empty_query_is_a_failed_budget_event(self) -> None:
+        backend_calls = 0
+
+        def backend(_request):
+            nonlocal backend_calls
+            backend_calls += 1
+            return ()
+
+        proxy = BudgetedSearchProxy("entrant", 20, backend)
+        with self.assertRaisesRegex(ValueError, "non-empty"):
+            proxy.search("   ")
+        self.assertEqual(0, backend_calls)
+        self.assertEqual(1, proxy.calls_used)
+        self.assertEqual("FAILED", proxy.traces[0].status)
+        self.assertEqual("UNEXPECTED_BACKEND_ERROR", proxy.traces[0].error_code)
+
     def test_url_reader_returns_typed_not_found_without_fallback(self) -> None:
         result = FakeURLReader({}).read("https://example.test/missing")
         self.assertEqual("NOT_FOUND", result.status)
@@ -164,6 +182,124 @@ class ToolBoundaryTests(unittest.TestCase):
         )
         self.assertFalse(hasattr(tools, "registry"))
         self.assertFalse(hasattr(tools, "judge_snapshot"))
+
+    def test_search_pro_normalizes_real_contract_and_traces_identity(self) -> None:
+        captured: dict[str, object] = {}
+
+        def transport(endpoint, headers, payload, timeout):
+            captured.update(
+                endpoint=endpoint,
+                headers=dict(headers),
+                payload=dict(payload),
+                timeout=timeout,
+            )
+            return TransportResponse(
+                200,
+                json.dumps(
+                    {
+                        "id": "backend-response-1",
+                        "request_id": payload["request_id"],
+                        "search_result": [
+                            {
+                                "title": " Example role ",
+                                "link": "https://jobs.example.test/live-role",
+                                "content": " Search snippet. ",
+                                "media": "Example",
+                            }
+                        ],
+                    }
+                ).encode("utf-8"),
+            )
+
+        secret = "test-secret-must-not-enter-trace"
+        proxy = BudgetedSearchProxy(
+            "fake-entrant",
+            20,
+            SearchProBackend(secret, count=7, transport=transport),
+        )
+        results = proxy.search("AI evaluation remote Europe")
+        self.assertEqual(
+            (
+                SearchResult(
+                    title="Example role",
+                    url="https://jobs.example.test/live-role",
+                    snippet="Search snippet.",
+                ),
+            ),
+            results,
+        )
+        payload = captured["payload"]
+        self.assertIsInstance(payload, dict)
+        assert isinstance(payload, dict)
+        self.assertEqual("search_pro", payload["search_engine"])
+        self.assertEqual(7, payload["count"])
+        trace = proxy.traces[0]
+        self.assertEqual(1, trace.call_number)
+        self.assertEqual("zhipu-web-search/search_pro", trace.backend_id)
+        self.assertEqual("backend-response-1", trace.backend_response_id)
+        self.assertEqual(1, trace.result_count)
+        self.assertEqual(0, trace.automatic_retries)
+        self.assertNotIn(secret, json.dumps(dataclasses.asdict(trace)))
+
+    def test_search_pro_http_failure_consumes_ticket_without_hidden_retry(self) -> None:
+        transport_calls = 0
+
+        def transport(_endpoint, _headers, payload, _timeout):
+            nonlocal transport_calls
+            transport_calls += 1
+            return TransportResponse(
+                429,
+                json.dumps(
+                    {
+                        "request_id": payload["request_id"],
+                        "error": {"code": "1302", "message": "rate limited"},
+                    }
+                ).encode("utf-8"),
+            )
+
+        proxy = BudgetedSearchProxy(
+            "fake-entrant", 20, SearchProBackend("test-key", transport=transport)
+        )
+        with self.assertRaisesRegex(SearchBackendError, "1302"):
+            proxy.search("query")
+        self.assertEqual(1, transport_calls)
+        self.assertEqual(1, proxy.calls_used)
+        trace = proxy.traces[0]
+        self.assertEqual("FAILED", trace.status)
+        self.assertEqual("1302", trace.error_code)
+        self.assertEqual(429, trace.http_status)
+        self.assertTrue(trace.retryable)
+        self.assertEqual(1, trace.backend_attempts)
+        self.assertEqual(0, trace.automatic_retries)
+
+    def test_search_pro_malformed_result_is_an_audited_failure(self) -> None:
+        def transport(_endpoint, _headers, payload, _timeout):
+            return TransportResponse(
+                200,
+                json.dumps(
+                    {
+                        "request_id": payload["request_id"],
+                        "search_result": [{"title": "Missing link"}],
+                    }
+                ).encode("utf-8"),
+            )
+
+        proxy = BudgetedSearchProxy(
+            "fake-entrant", 20, SearchProBackend("test-key", transport=transport)
+        )
+        with self.assertRaisesRegex(SearchBackendError, "missing title or link"):
+            proxy.search("query")
+        self.assertEqual(1, proxy.calls_used)
+        self.assertEqual("INVALID_RESULT", proxy.traces[0].error_code)
+
+    def test_search_pro_rejects_overlong_query_as_one_failed_budget_event(self) -> None:
+        proxy = BudgetedSearchProxy(
+            "fake-entrant", 20, SearchProBackend("test-key", transport=lambda *_: None)
+        )
+        with self.assertRaisesRegex(SearchBackendError, "70-character"):
+            proxy.search("x" * 71)
+        self.assertEqual(1, proxy.calls_used)
+        self.assertEqual("INVALID_QUERY", proxy.traces[0].error_code)
 
 
 class RunnerAndJudgeTests(unittest.TestCase):
@@ -282,6 +418,12 @@ class CLIGateTests(unittest.TestCase):
         self.assertEqual("OFFLINE_ONLY", result["mode"])
         self.assertFalse(result["official_match_authorized"])
         self.assertEqual(0, result["live_provider_adapters"])
+        self.assertTrue(result["search_pro_backend_available"])
+        self.assertTrue(result["live_search_requires_explicit_smoke_authorization"])
+
+    def test_live_smoke_requires_manual_authorization_before_key_lookup(self) -> None:
+        with self.assertRaisesRegex(ValueError, "authorize-live-search-smoke"):
+            search_cup_main(["live-smoke", "--query", "non-official smoke"])
 
     def test_live_provider_is_explicitly_unimplemented(self) -> None:
         with self.assertRaisesRegex(LiveProviderNotImplemented, "outside ENG-SC-01-P0"):


### PR DESCRIPTION
Implements the authorized **ENG-SC-01-P1** slice of #8 on top of the P0 fairness harness in #9.

## What changed

- adds a provider-independent live backend for Zhipu Web Search API with `search_engine=search_pro`
- maps the official `title` / `link` / `content` response into the existing common `SearchResult`
- routes the Fake Entrant smoke through the same `EntrantTools.search_web` contract future providers will receive
- records auditable call number, query, result count, backend/request identity, typed error, HTTP status, retryability, timing, and explicit retry count
- keeps one SearchProxy invocation equal to one budget event for success, HTTP failure, protocol failure, or invalid input
- exposes only a manually gated `live-smoke` command with 1–3 queries and no model adapter
- bumps package, runtime, and container metadata together to v0.9.0

The adapter follows the official Web Search API contract:
https://docs.bigmodel.cn/api-reference/%E5%B7%A5%E5%85%B7-api/%E7%BD%91%E7%BB%9C%E6%90%9C%E7%B4%A2

## Safety boundary

- **0 OpenAI / Gemini / DeepSeek / GLM model calls**
- **0 official-match execution paths**
- no automatic retry; an operator retry must consume another SearchProxy ticket
- API key is read only from a named environment variable and never enters trace/result/error/Git content
- live smoke requires the explicit `--authorize-live-search-smoke` flag and is capped at three queries
- Candidate Card and CompetitionSpec files are unchanged
- hidden-registry handles remain absent from `EntrantTools`
- the P0 call-21 rejection, freeze/hash, provider isolation, and hidden-registry gates remain covered

## Validation

- GitHub Actions [run #34](https://github.com/aerenkolstein-code/llm-evaluation-lab/actions/runs/31934490114): **GREEN**
- complete repository suite: **59/59 PASS**
- SEARCH-CUP P0/P1 tests: **27/27 PASS**
- P0/P1 preflight and deterministic four-entrant demo: **PASS**
- checked experiment + Historical Failure Benchmark: **PASS**
- read-only FastAPI smoke: **PASS**
- Docker build + v0.9.0 CLI + mounted SQLite + container API smoke: **PASS**
- clean non-editable wheel install and packaged `search_cup/search_pro.py`: **PASS**
- privacy/credential scan: **PASS**
- remote P0 base preserved exactly: `ab8da32016301c69c3bab7de02e0b784f4eaa941`
- CandidateCard fingerprint unchanged: `ad9394a5eb6f0c795f84e4f32d03394105d27ee61b2a080717f8b9f1fc9df497`
- CompetitionSpec fingerprint unchanged: `7877472af4d0909f117872f39c028f40b300d637f16120e311bed8b996e89743`

## Live-smoke status

**GREEN — the real-backend P1 Stop Condition is closed.**

- authorized one-shot workflow: [P1 SearchPro Live Smoke #3](https://github.com/aerenkolstein-code/llm-evaluation-lab/actions/runs/31950457695)
- real backend: `zhipu-web-search/search_pro`
- Fake Entrant calls: **2 requested / 2 used / 2 succeeded**
- normalized results: **10 + 5**
- backend attempts: **1 + 1**
- automatic retries: **0**
- provider adapters invoked: **0**
- hidden registry loaded: **false**
- official match authorized: **false**
- credentials logged: **false**
- evidence artifact digest: `sha256:547768971d30dc355fa75f22d1268325cc75e820d22070598d9693890aca37da`
- smoke JSON SHA-256: `147e85dc4b5999a2f3ebefdbadd3c69625b41795f7182b570af770b8eb968709`

The preceding workflow-configuration attempts failed before job allocation and consumed zero search calls. The successful run used the repository secret only inside GitHub Actions and verified that the exact secret value was absent from the emitted evidence. P1 stops here; P2 remains unauthorized pending Board / Plan Office review.

## Still out of scope

- four provider adapters (P2)
- runner/immutable official evidence work beyond P0 (P3)
- private hidden-registry execution (P4)
- official match preflight/execution (P5)
- the 80-call official match

The P1 evidence is complete. This PR remains Draft for Board / Plan Office review; P2 and the official match remain unauthorized.