### PR TITLE
docs: align Eval Lab with v1.0 methodology and roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,43 @@
 # LLM Evaluation Lab
 
-**Reproducible LLM evaluation harness for failure mechanisms, mitigation experiments, and regression testing.**
+**Reproducible evaluation lab for failure mechanisms, mitigation experiments, regression testing, independent system gates, and longitudinal evidence.**
 
 [![Test](https://github.com/aerenkolstein-code/llm-evaluation-lab/actions/workflows/test.yml/badge.svg)](https://github.com/aerenkolstein-code/llm-evaluation-lab/actions/workflows/test.yml)
 
 ## Current evaluation focus
 
-LLM Evaluation Lab is the **A2 / Measure the system** repository for the approved **Persistent AI Companion** program. Its role is to turn continuity claims into reproducible evidence rather than letting the product grade itself.
+LLM Evaluation Lab is the **A2 / Measure the system** repository. It is not a QA annex that lets one product grade itself. Its job is to turn observed AI-system failures and continuity claims into reproducible cases, explicit oracles, comparative evidence, falsifiable mitigation hypotheses, and regression gates.
 
-The planned Companion evaluation direction includes identity and relationship continuity, shared-history hallucination, model-switch continuity, initiative regressions, and staged **Day 1 / 7 / 30 / 90** longitudinal gates. Those Companion benchmarks are active roadmap work, **not claims of completed or merged evaluation results**.
+The paired [Companion-Mind](https://github.com/aerenkolstein-code/Companion-Mind) repository is the A1 / implementation counterpart:
+
+> **A1 builds the system. A2 measures whether it actually improves.**
+
+The current product-linked evaluation gate is **A019 / Gate E1 — Durable Journal black-box evaluation**. The published A2 Wave 1 plan defines durability, ordering, dedupe, crash/restart recovery, correction, secret exclusion, and UNKNOWN semantics as zero-tolerance observable invariants. The plan is published; implementation and Gate E1 execution remain separately gated and wait for an A1-D candidate and sanctioned black-box seam.
+
+After E1, the product-linked evaluation path follows the current personal-first runtime sequence:
+
+```text
+Journal / E1
+→ Context Engine / Owned Home
+→ Retrieval / Authority Routing
+→ Model Gateway / model-switch continuity
+→ W1 operational independence
+→ Living Lab longitudinal reliability
+→ W2 evidence readiness
+```
+
+This does **not** pre-select a commercial companion product. Commercial evaluation becomes relevant only if later product discovery explicitly extracts one from long-term use evidence.
+
+The broader lab now has four connected lanes:
+
+1. **Failure Mechanism Lab** — failure taxonomy, mechanism clustering, reproducible cases, baseline/treatment, falsification, and regression.
+2. **A2 Independent System Gates** — black-box evidence for A1/runtime promises without copying A1 implementation authority.
+3. **RAW Harvest + Historical / Era Benchmarks** — private longitudinal evidence is mined into public-safe mechanisms, replay cases, rubrics, and cross-generation comparisons; private Raw/L0 stays private.
+4. **Longitudinal Cognitive / Persona Research** — concept growth, reasoning trajectory, world-model evolution, personality/relationship continuity, prior lock-in, attractor stability, replay effects, and related long-horizon questions when evidence and protocol are mature enough.
+
+See [docs/current-roadmap.md](docs/current-roadmap.md), [docs/methodology.md](docs/methodology.md), and [docs/method-lineage.md](docs/method-lineage.md).
 
 The `main` branch below remains the stable public evidence base for the First Closed Loop, Historical Failure Benchmark, immutable experiment tracking, read-only query API, and Docker reproducibility.
-
-The paired [Companion-Mind](https://github.com/aerenkolstein-code/Companion-Mind) repository is the A1 / implementation counterpart: Companion-Mind builds the system; LLM Evaluation Lab measures whether it actually improves.
 
 **B / Search Cup** is a separate Search/Tooling workstream that also lives in this repository for infrastructure reuse. Repository location does not make Search Cup part of A2, and its later live/provider phases remain separately gated.
 
@@ -34,9 +59,9 @@ The paired [Companion-Mind](https://github.com/aerenkolstein-code/Companion-Mind
 flowchart LR
   A[Observed failure] --> B[EvaluationCase]
   B --> C[Baseline]
-  C --> D[Mitigation]
-  D --> E[Metric]
-  E --> F[Runtime Guard]
+  C --> D[Mitigation hypothesis]
+  D --> E[Independent check]
+  E --> F[Runtime guard]
   F --> G[Regression]
 ```
 
@@ -178,11 +203,39 @@ registry image or production deployment.
 
 ## Executable integration v0.3
 
-The experiment now owns a complete `mitigation-spec/v1` contract, validates it,
+The experiment owns a complete `mitigation-spec/v1` contract, validates it,
 emits canonical JSON, and instantiates Companion-Mind's real `ClosureGuard` from
 that document. The evaluation report records the runtime-loaded mitigation ID,
 safeguard ID, schema version, and canonical SHA-256 fingerprint. This makes the
 boundary explicit: Eval Lab specifies and verifies; Companion-Mind implements.
+
+## Methodology
+
+The long-term loop is broader than a single score:
+
+```text
+Observed failure / friction
+→ phenomenon classification
+→ mechanism hypothesis / cluster
+→ reproducible case
+→ rubric / oracle
+→ baseline
+→ mitigation hypothesis
+→ independent verification / falsification
+→ regression
+→ cross-method comparison
+→ review
+→ best-known solution
+```
+
+Failure reproduction comes before patching. Mechanism-level explanations are preferred over one-off rules. `BLOCKED` and `NOT EVALUABLE` are not passes. Regression is part of a mitigation, not an optional cleanup step.
+
+Historical evidence adds another distinction:
+
+- **Historical Observed Baseline** — score what an older system actually did, while preserving the limits of incomplete historical environment reconstruction.
+- **Frozen Replay Benchmark** — sanitize and freeze the necessary task, context, constraints, evidence and oracle so later models or runtimes can be compared on the same replayable case.
+
+Private Raw/L0 is evidence input, not a public dataset. See [docs/methodology.md](docs/methodology.md) and [docs/method-lineage.md](docs/method-lineage.md).
 
 ## Evidence boundary
 
@@ -195,12 +248,12 @@ boundary explicit: Eval Lab specifies and verifies; Companion-Mind implements.
 - baseline and mitigation comparison;
 - accuracy and premature-closure metrics;
 - JSON and Markdown report output;
-- checked result artifact and known-bad regression gate.
+- checked result artifact and known-bad regression gate;
 - validated 12-cluster, 24-case Historical Failure Benchmark;
-- one uniform evidence-and-constraint gate with zero per-observation rules.
+- one uniform evidence-and-constraint gate with zero per-observation rules;
 - immutable SQLite experiment-run persistence and metadata query;
-- structured JSON lifecycle logging.
-- loopback-first read-only FastAPI health, list and detail endpoints.
+- structured JSON lifecycle logging;
+- loopback-first read-only FastAPI health, list and detail endpoints;
 - non-root Docker packaging with pinned Companion-Mind runtime commit.
 
 ### Measured in the current demonstration
@@ -209,27 +262,38 @@ boundary explicit: Eval Lab specifies and verifies; Companion-Mind implements.
 - guarded accuracy: **100%**;
 - premature closure rate: **100% → 0%**;
 - known recurrence variants caught: **4/4**;
-- runtime integration status: **PASS**.
+- runtime integration status: **PASS**;
 - historical benchmark baseline: **50%**;
 - uniform constraint gate: **100%**;
 - historical traps caught: **12/12**;
 - evaluation tests: **32/32**;
 - SQLite persistence and readback: **PASS**;
-- duplicate run protection: **PASS**.
+- duplicate run protection: **PASS**;
 - API route write methods exposed: **0**;
-- read-only query mutation check: **PASS**.
+- read-only query mutation check: **PASS**;
 - Docker image build: **PASS**;
 - containerized CLI/API smoke: **PASS**.
+
+### Planned / separately gated
+
+- A019 / Gate E1 black-box execution against an A1-D candidate;
+- Context Engine / Retrieval / Model Gateway evaluation profiles;
+- W1 operational-independence evaluation;
+- Living Lab longitudinal reliability profiles;
+- historical/era replay packs and cross-generation continuity comparisons beyond the existing public Historical Failure Benchmark;
+- long-horizon Persona/Relationship, concept-growth, attractor and world-model studies.
 
 ### Not claimed
 
 - production deployment;
 - broad model generalization;
 - scientific benchmark validity;
+- corpus representativeness;
 - enterprise-grade reliability;
-- live-LLM effectiveness or statistical significance.
-- authenticated or production-ready API deployment.
-- bit-for-bit dependency or base-image reproducibility.
+- live-LLM effectiveness or statistical significance;
+- authenticated or production-ready API deployment;
+- bit-for-bit dependency or base-image reproducibility;
+- objective ground truth for personality, relationship, consciousness, or subjective experience.
 
 ## Artifact map
 
@@ -239,18 +303,24 @@ boundary explicit: Eval Lab specifies and verifies; Companion-Mind implements.
 - `results/EVAL-CASE-001.json` — checked deterministic result
 - `tests/test_evaluation.py` — loader, reproducibility, reporting, and regression assertions
 - `schemas/` — shared evaluation and mitigation contracts
+- `docs/a2/` — approved A2 planning and reconciliation records
+- `docs/current-roadmap.md` — public-safe current evaluation placement and future gates
+- `docs/methodology.md` — failure-science and evidence methodology
+- `docs/method-lineage.md` — private-evidence to public-evaluation lineage
 - `Dockerfile` — non-root container build for CLI and read-only API reproduction
 
 ## Roadmap
 
-**Operationalization baseline complete** — SQLite experiment tracking, structured
-logging, a read-only FastAPI query surface, and Docker CLI/API reproduction are
-implemented. Further infrastructure expansion requires a separate scope decision.
+**Operationalization baseline is complete.** The current public evidence base already includes executable failure reproduction, mitigation integration, historical mechanism compression, immutable run tracking, structured logs, read-only querying, and container reproduction.
+
+The next product-linked evaluation is **A019 / Gate E1**, but execution waits for separate authorization and an A1-D candidate. Later evaluation expands with the system under test rather than pre-building empty benchmark infrastructure: Context/Owned Home → W1 → Living Lab → W2.
+
+A separate RAW-harvest research lane may derive public-safe historical and era benchmarks from private longitudinal evidence. Archive recovery alone is not treated as completed evaluation harvest.
 
 ## Privacy
 
 The fixtures preserve failure mechanisms without publishing the private scenes that revealed them. The historical suite uses synthetic neutral scenarios and excludes source quotations and archive locators. The repository contains no private Raw/L0 material, credentials, account data, client documents, personal records, or links to private archives.
 
-The API returns whatever canonical result was stored by the operator. Only
-public-safe runs belong in a publicly reachable deployment; this artifact binds
-to localhost by default and intentionally provides no authentication.
+Historical observed baselines and future replay packs must keep the same boundary: aggregate or sanitized evidence may become public; private source bodies and reverse-lookup locators do not.
+
+The API returns whatever canonical result was stored by the operator. Only public-safe runs belong in a publicly reachable deployment; this artifact binds to localhost by default and intentionally provides no authentication.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,8 +1,61 @@
-# LLM Evaluation Lab｜第三仓库公开形态
+# LLM Evaluation Lab｜A2 / Measure the system
 
-**面向错误机制、纵向变化、改进验证与回归测试的可运行评测架。**
+**面向失败机制、改进验证、独立系统 Gate、回归测试与长期证据的可运行评测实验室。**
 
 Portfolio Status：**CURRENT ARTIFACT** · Evidence Level：**E3——可复现的 public-safe 评测**
+
+LLM Evaluation Lab 不再把自己描述成“第三仓库概念稿”，也不是 Companion-Mind 的附属 QA 仓。它负责把真实或历史 AI 系统失败转换成：可复现 case、明确 rubric/oracle、baseline、可证伪 mitigation、独立验证与 regression evidence。
+
+配套的 [Companion-Mind](https://github.com/aerenkolstein-code/Companion-Mind) 是 A1 / implementation 仓：
+
+> **A1 builds the system. A2 measures whether it actually improves.**
+
+## 当前最近评测 Gate
+
+当前产品关联的第一硬 Gate 是 **A019 / Gate E1｜Durable Journal black-box evaluation**，不是旧叙事里的 Day 1 / 7 / 30 / 90 Persona 主线。
+
+已发布的 A2 Wave 1 Stage Plan 把以下八个维度定义为独立黑盒评测目标：
+
+```text
+Durability
+Ordering
+Dedupe
+Crash Recovery
+Restart Recovery
+Correction
+Secret Exclusion
+UNKNOWN Semantics
+```
+
+E1 是 all-of gate：zero-tolerance invariant 不能用平均分冲掉。当前 Stage Plan 已发布，但实现与 E1 实跑仍需独立授权，并等待 A1-D candidate 与 sanctioned black-box seam。
+
+E1 之后，评测对象随系统主线继续生长：
+
+```text
+Journal / E1
+→ Context Engine / Owned Home
+→ Retrieval / Authority Router
+→ Model Gateway / model-switch continuity
+→ W1 operational independence
+→ Living Lab longitudinal reliability
+→ W2 evidence readiness
+```
+
+这条路线不预先选定商业伴侣产品；只有未来真实长期使用证据支持并重新立项时，才会出现商业评测 profile。
+
+## 四条长期主线
+
+1. **Failure Mechanism Lab**：failure taxonomy、mechanism clustering、minimal pair、TRAP/CONTROL、baseline、mitigation、falsification、regression。
+2. **A2 Independent System Gates**：独立验证 A1/Runtime 承诺，不复制 A1 schema，不让系统自己给自己发证书。
+3. **RAW Harvest + Historical / Era Benchmarks**：私有长期 RAW/L0 作为 evidence mine，提炼 public-safe mechanism、synthetic replay、rubric 与跨代比较；原始私人材料不进公开仓。
+4. **Longitudinal Cognitive / Persona Research**：Concept Growth、Reasoning Trajectory、World Model Evolution、Personality/Relationship Continuity、Prior Lock-in、Attractor Stability、Replay 等长期问题，在证据和 protocol 足够成熟时再正式 benchmark 化。
+
+当前路线详见：
+- `docs/current-roadmap.md`
+- `docs/methodology.md`
+- `docs/method-lineage.md`
+
+## First Closed Loop
 
 首个闭环 `EVAL-CASE-001` 测试 Premature Parent Closure：一个局部子任务完成，另一个必要子任务仍未闭环，系统却把父目标写成完成。
 
@@ -13,7 +66,7 @@ Portfolio Status：**CURRENT ARTIFACT** · Evidence Level：**E3——可复现�
 | 朴素基线 | 20% | 100% | 4 |
 | Companion-Mind Closure Guard | 100% | 0% | 0 |
 
-这不是通用模型性能声明，而是第一个能被陌生人复跑的 Case → Failure → Metric → Mitigation → Guard → Regression 闭环。
+这不是通用模型性能声明，而是第一个能被陌生人复跑的 Case → Failure → Baseline → Mitigation → Guard → Regression 闭环。
 
 ## Executable Integration v0.3
 
@@ -27,7 +80,7 @@ llm-eval \
 companion-mind validate-mitigation --mitigation-spec /tmp/mitigation.json
 ```
 
-`llm-eval` 现在负责校验并输出完整的 `mitigation-spec/v1`，再用它实例化 Companion-Mind 的真实 `ClosureGuard`。报告同时记录 runtime 实际加载的 mitigation ID、safeguard ID、schema version 与 canonical SHA-256 fingerprint，从而证明“写入评测报告的配置”与“运行时真正执行的配置”一致。
+`llm-eval` 校验并输出完整的 `mitigation-spec/v1`，再用它实例化 Companion-Mind 的真实 `ClosureGuard`。报告记录 runtime 实际加载的 mitigation ID、safeguard ID、schema version 与 canonical SHA-256 fingerprint，从而证明“评测里写的 mitigation”与“运行时实际执行的 mitigation”一致。
 
 当前 **32/32 tests** 覆盖 Case/Spec 同步、非法规范、状态集合冲突、真实 runtime 回归、checked result、历史机制簇、最小对照、隐私定位符、双套 suite 的 SQLite 持久化、重复 run 防覆盖、结构化日志、只读 API、双格式报告、CLI 原子输出与退出码契约。
 
@@ -41,26 +94,59 @@ llm-eval \
   --cases cases/anonymized/premature-parent-closure.md
 ```
 
-当前确定性基准：置信表面基线 **50%**，统一证据—约束门 **100%**，已抓住 **12/12** 个已知陷阱，逐观察规则数 **0**。全仓测试现为 **32/32**。这些数字只描述合成结构基准，不代表真实模型泛化、生产可靠性或科学 benchmark 有效性。
+当前确定性基准：置信表面基线 **50%**，统一证据—约束门 **100%**，已抓住 **12/12** 个已知陷阱，逐观察规则数 **0**。这些数字只描述合成结构基准，不代表真实模型泛化、生产可靠性或科学 benchmark 有效性。
+
+## 方法论主链
+
+长期方法现在冻结为：
+
+```text
+Observed Failure / Friction
+→ Phenomenon Classification
+→ Mechanism Hypothesis / Cluster
+→ Reproducible Case
+→ Rubric / Oracle
+→ Baseline
+→ Mitigation Hypothesis
+→ Independent Verification / Falsification
+→ Regression
+→ Cross-Method Comparison
+→ Review
+→ Best-Known Solution
+```
+
+原则是：先复现，再修；先区分现象和机制，再归因；Falsification 与 PASS 同样重要；Regression 是 mitigation 的一部分；`BLOCKED / NOT EVALUABLE` 不能伪装成 GREEN。
+
+而且“AI failure”不再自动等于“模型错了”。候选层包括：model、context assembly、retrieval/authority routing、tool/provider adapter、durable state/journal、persona/relationship continuity、model switching、crash/restart 等。
+
+## RAW Harvest 与历史 benchmark
+
+历史 RAW 具有两种不同的评测价值：
+
+- **Historical Observed Baseline**：按后来冻结的 rubric 回评旧模型当年真实输出；保留其历史环境无法完全复原的限制。
+- **Frozen Replay Benchmark**：把必要 task、visible context、约束、证据和 oracle 脱敏冻结，让后来的模型或 Runtime 在同一个可复跑输入包上比较。
+
+因此：
+
+> **Archive Complete ≠ Eval Harvest Complete。**
+
+原矿恢复和归档只是第一层完成。真正 Eval Harvest 还要经过 candidate → mechanism → anonymization/synthetic abstraction → rubric/oracle → baseline → mitigation → falsification → regression → longitudinal comparison。
+
+私人 RAW/L0 是 evidence mine，不是公开训练集。公开仓只接受脱敏/合成 case、机制、rubric、protocol、aggregate metric、mitigation spec、regression evidence 和 public-safe trace。
 
 ## Persistent Experiment Tracking v0.5
 
-`llm-eval` 现在可以把每次运行原子写入 SQLite，记录 run ID、suite version、model/policy、prompt version、metrics、latency、token cost、git commit、UTC timestamp 与 canonical result JSON。`run_id` 不可变，重复写入会被拒绝；`--list-runs` 可回读元数据，`--log-json` 输出结构化生命周期日志。数据库属于运行证据，默认被 git 忽略，不进入公开仓库。
+`llm-eval` 可以把每次运行原子写入 SQLite，记录 run ID、suite version、model/policy、prompt version、metrics、latency、token cost、git commit、UTC timestamp 与 canonical result JSON。`run_id` 不可变，重复写入会被拒绝；`--list-runs` 可回读元数据，`--log-json` 输出结构化生命周期日志。数据库属于运行证据，默认被 git 忽略，不进入公开仓库。
 
 ## Read-Only FastAPI Query Surface v0.6
 
-`llm-eval-api --store /tmp/eval-runs.sqlite3` 提供三个只读端点：
-`/healthz`、`/v1/runs` 与 `/v1/runs/{run_id}`。SQLite 以 `mode=ro`
-和 `query_only` 打开；接口默认只监听 `127.0.0.1`，写方法数为 **0**，
-查询前后数据库哈希保持不变。
+`llm-eval-api --store /tmp/eval-runs.sqlite3` 提供三个只读端点：`/healthz`、`/v1/runs` 与 `/v1/runs/{run_id}`。SQLite 以 `mode=ro` 和 `query_only` 打开；接口默认只监听 `127.0.0.1`，写方法数为 **0**，查询前后数据库哈希保持不变。
 
-该接口只适合本地、public-safe 实验记录查询。当前没有认证、授权、限流、
-公网部署或生产可靠性声明；操作方不得把私密提示词、档案定位符或账号信息写入实验元数据。
+该接口只适合本地、public-safe 实验记录查询。当前没有认证、授权、限流、公网部署或生产可靠性声明。
 
 ## Docker Reproducibility v0.7
 
-仓库新增唯一一个受控文件 `Dockerfile`，将 Companion-Mind runtime 固定在
-`c6a2128271532746a5570b99ce0ccdea4618db4e`，容器以非 root 用户运行。
+仓库包含一个受控 `Dockerfile`，将 Companion-Mind runtime 固定在 `c6a2128271532746a5570b99ce0ccdea4618db4e`，容器以非 root 用户运行。
 
 ```bash
 docker build -t llm-evaluation-lab:0.7 .
@@ -69,8 +155,23 @@ docker run --rm llm-evaluation-lab:0.7 \
   --cases cases/anonymized/premature-parent-closure.md
 ```
 
-GitHub Actions 会从 clean checkout 构建镜像、核验 `0.7.0`、复跑 24 案例历史基准、
-在挂载目录中生成 SQLite 记录，并通过真实 HTTP 查询容器化 API。它证明本地容器复跑能力，
-不代表已经发布 registry image、完成云部署或达到生产可靠性。
+GitHub Actions 会从 clean checkout 构建镜像、核验 `0.7.0`、复跑 24 案例历史基准、在挂载目录中生成 SQLite 记录，并通过真实 HTTP 查询容器化 API。它证明本地容器复跑能力，不代表已发布 registry image、完成云部署或达到生产可靠性。
 
-第三仓仍保留 concept growth、prior lock-in、world-model drift、longitudinal evolution 与 experimental timeline；failure taxonomy 只是公开接口，不取代纵向评估内核。
+## Claims Boundary
+
+当前**已经实现**的是：First Closed Loop、Historical Failure Benchmark、MitigationSpec integration、SQLite immutable experiment tracking、结构化日志、只读 API、Docker reproducibility 与当前 32/32 tests。
+
+当前**尚未宣称**的是：
+
+```text
+scientific benchmark validity
+corpus representativeness
+broad model generalization
+live-model statistical significance
+production / enterprise eval platform
+人格 / 意识的客观 ground truth
+private RAW 可公开训练
+一个总分代表长期 AI 质量
+```
+
+第三仓时期留下的 concept growth、prior lock-in、world-model drift、experimental timeline 等问题继续保留为长期 research program；它们不再冒充当前首期施工命令。

--- a/docs/current-roadmap.md
+++ b/docs/current-roadmap.md
@@ -1,0 +1,204 @@
+# Current roadmap — failure science, independent gates, and longitudinal evidence
+
+**Status:** public-safe evaluation orientation  
+**Scope:** roadmap/narrative only; not an implementation authority or completion claim
+
+LLM Evaluation Lab is the **A2 / Measure the system** repository. Its job is to turn AI-system failures, continuity claims and long-term observations into reproducible evidence that can challenge implementation claims rather than merely repeat them.
+
+The current public evidence base already includes:
+
+- First Closed Loop: Premature Parent Closure reproduction, mitigation and regression;
+- Historical Failure Benchmark: 89 reviewed observations → 18 raw categories → 12 mechanism clusters → 24 public-safe synthetic cases;
+- executable `MitigationSpec` integration with Companion-Mind;
+- immutable SQLite experiment tracking;
+- structured lifecycle logging;
+- read-only FastAPI evidence querying;
+- Docker CLI/API reproduction.
+
+These are implemented artifacts. The roadmap below describes what comes next and what remains separately gated.
+
+## Evaluation mission
+
+```text
+Observed failure / friction
+→ phenomenon classification
+→ mechanism hypothesis / cluster
+→ reproducible case
+→ rubric / oracle
+→ baseline
+→ mitigation hypothesis
+→ independent verification / falsification
+→ regression
+→ cross-method comparison
+→ review
+→ best-known solution
+```
+
+The lab prefers reproducible mechanisms over one-off rules. It treats `BLOCKED` and `NOT EVALUABLE` as real outcomes. A mitigation is not complete without regression evidence when recurrence can be tested.
+
+## Four connected lanes
+
+### Lane A — Failure Mechanism Lab
+
+Convert real or historical failures into reproducible mechanism experiments.
+
+Typical assets:
+
+```text
+failure taxonomy
+mechanism clusters
+minimal pairs / TRAP-CONTROL
+rubrics / oracles
+baselines
+mitigation specs
+falsification results
+regression suites
+best-known-solution notes
+```
+
+The existing Historical Failure Benchmark is the first executable example of this lane.
+
+### Lane B — A2 Independent System Gates
+
+Measure whether A1 / Companion-Mind actually satisfies its public contracts and stage promises.
+
+The immediate product-linked gate is:
+
+> **A019 / Gate E1 — Durable Journal black-box evaluation.**
+
+The approved A2 Wave 1 plan covers:
+
+```text
+Durability
+Ordering
+Dedupe
+Crash Recovery
+Restart Recovery
+Correction
+Secret Exclusion
+UNKNOWN Semantics
+```
+
+Gate E1 is an all-of gate with zero-tolerance invariants. The planning document is published. Actual A2 implementation and Gate E1 execution remain separately gated and require an A1-D candidate plus a sanctioned black-box seam.
+
+After E1, evaluation expands with the system under test:
+
+```text
+Journal / E1
+→ Context Engine / Owned Home
+→ Retrieval / Authority Routing
+→ Model Gateway / model-switch continuity
+→ W1 operational independence
+→ Living Lab longitudinal reliability
+→ W2 evidence readiness
+```
+
+A2 supplies evidence at W2; it does not decide whether a commercial product should exist.
+
+### Lane C — RAW Harvest + Historical / Era Benchmarks
+
+Private longitudinal evidence can be a failure mine, intervention history and historical benchmark source without becoming a public dataset.
+
+The transformation is:
+
+```text
+Archive Complete
+→ candidate selection
+→ mechanism classification
+→ anonymization / synthetic abstraction
+→ rubric / oracle
+→ baseline
+→ mitigation / falsification
+→ regression
+→ longitudinal comparison
+```
+
+Historical evidence has two distinct forms:
+
+- **Historical Observed Baseline** — score what the historical system actually did, while preserving uncertainty about unreconstructable model/platform internals.
+- **Frozen Replay Benchmark** — sanitize and freeze the necessary task, context, constraints, evidence and oracle so later models or runtimes can be compared on the same replayable case.
+
+Future **Era Benchmark Packs** may combine both forms with cross-model and model-vs-runtime comparisons. Era packs are a roadmap design target, not a claim that a public era benchmark suite is implemented today.
+
+One especially useful historical category is a **Context-only Longitudinal Baseline**: naturally occurring long-context continuity before external archive/retrieval/runtime support existed. Such a baseline can become a regression floor for later runtime-assisted continuity, subject to the limitations of historical observation.
+
+### Lane D — Longitudinal Cognitive / Persona Research
+
+The lab retains the long-horizon questions that motivated the earlier AI Longitudinal Evaluation concept:
+
+```text
+Concept Growth
+Reasoning Trajectory
+World Model Evolution
+Personality / Relationship Continuity
+Prior Lock-in
+Attractor Stability
+Information Gain
+Replay Selection Bias
+Cost of Becoming
+Consolidation Cost
+Canonical Persona / Experimental Timeline
+Cross-Raw Integration
+```
+
+These are research directions, not automatically implemented metrics. They become executable benchmark work only when the evidence, operational definition and protocol are mature enough.
+
+## Historical continuity dimensions
+
+Longitudinal continuity should not collapse into one “persona similarity” score. Candidate dimensions include:
+
+```text
+Identity Consistency
+Biography Fidelity
+Relationship-State Continuity
+Shared-History Hallucination
+Correction Retention
+Topic Reactivation
+Cross-Window Continuity
+Model-Switch Identity Continuity
+Authority Fidelity
+Contradiction / Confabulation Rate
+```
+
+Future controlled studies may also measure fidelity decay with context depth, time-to-recurrence after corrections, A→B→A topic recovery, and whether retrieval/runtime support improves or suppresses bare-model capability.
+
+## A1 / A2 authority boundary
+
+```text
+A1 / Companion-Mind
+= build the system
+= own implementation, internal storage mechanics and conformance
+
+A2 / LLM Evaluation Lab
+= measure the system
+= own independent cases, manifests, evidence, comparison and verdicts
+```
+
+A1 cannot self-certify the independent A2 gate. A2 cannot copy A1 schemas into a second authority or mutate A1 Current / Persona / Relationship truth.
+
+## Privacy boundary
+
+Private Raw/L0 remains private evidence. Public assets may contain anonymized/synthetic cases, mechanisms, rubrics, protocols, aggregate metrics, mitigation specs, regression evidence and public-safe traces.
+
+The repository must not publish private conversation bodies, reverse-lookup archive locators, credentials, account data, client material, private relationship/family records, medical/financial data or other non-public source material.
+
+## Claims boundary
+
+This roadmap does **not** claim:
+
+- scientific benchmark validity;
+- representative corpus coverage;
+- broad model generalization;
+- live-model statistical significance;
+- a production evaluation platform;
+- a completed public Era Benchmark Pack;
+- objective ground truth for personality, relationship, consciousness or subjective experience;
+- that private Raw is available for public training.
+
+## Short form
+
+> **A1 builds. A2 measures.**
+>
+> **The mine is longitudinal. The lab makes it reproducible.**
+>
+> **A benchmark should survive time, model changes, runtime changes, and our own interventions.**

--- a/docs/method-lineage.md
+++ b/docs/method-lineage.md
@@ -1,5 +1,9 @@
 # Method lineage
 
+LLM Evaluation Lab separates private longitudinal evidence, public-safe evaluation assets, and implementation authority.
+
+The core lineage is:
+
 ```text
 Raw / L0: what happened
 → L1: what changed the trajectory
@@ -9,12 +13,111 @@ Raw / L0: what happened
 → Stress Test: how to expose it deliberately
 → Mitigation Experiment: whether an intervention works
 → Regression Test: whether the failure returns
+→ Best-Known Solution: what current evidence supports
 ```
 
-For `HISTORICAL-FAILURE-BENCHMARK-v1`, the public boundary is crossed only after
-the Errorbook layer: 89 reviewed correction chains and 18 raw categories are
-compressed into 12 mechanism clusters, then reconstructed as 24 synthetic
-public-safe minimal-pair cases. The repository contains the reconstructed cases,
-not the underlying evidence corpus.
+For `HISTORICAL-FAILURE-BENCHMARK-v1`, the public boundary is crossed only after the private evidence layer has been reviewed: 89 correction observations and 18 raw categories are compressed into 12 mechanism clusters, then reconstructed as 24 synthetic public-safe minimal-pair cases. The repository contains the reconstructed cases, not the underlying evidence corpus.
 
-The repository does not publish private L0/L1/L2 material. It publishes public-safe method cards and reproducible cases derived from reviewed sources.
+## Archive Complete is not Eval Harvest Complete
+
+Recovering an old conversation or evidence package is only the first layer of completion.
+
+```text
+Archive Complete
+= recover source
+  → verify integrity / continuity / provenance
+  → confirm time and source boundary
+  → archive
+```
+
+A useful evaluation harvest requires a second transformation:
+
+```text
+Eval Harvest Complete
+= Raw candidate
+  → failure / intervention / continuity candidate
+  → phenomenon + mechanism classification
+  → anonymization / synthetic abstraction
+  → rubric / oracle
+  → baseline
+  → mitigation hypothesis
+  → verification / falsification
+  → regression
+  → longitudinal comparison
+```
+
+Not every archived turn deserves evaluation treatment. The useful subset is the one that can support a reproducible question, a discriminating mechanism hypothesis, a matched comparison, a later regression, or a grounded historical baseline.
+
+## Historical observation and frozen replay are different assets
+
+Historical Raw can support two distinct products:
+
+### Historical Observed Baseline
+
+A later evaluator scores what the historical system actually produced.
+
+This preserves naturalistic behavior and the original correction chain, but the exact historical model build, hidden system behavior, memory layer, context truncation and tool environment may not be fully reconstructable. It is therefore historical evidence, not a strict rerunnable causal experiment.
+
+### Frozen Replay Benchmark
+
+The evaluator extracts and sanitizes the necessary task, visible context, constraints, prior corrections, source evidence and oracle into a replayable pack. Modern models, retrieval policies or runtimes can then be compared against the same frozen case.
+
+These results must remain labeled separately:
+
+```text
+historical observed score ≠ replay score
+```
+
+## Era Benchmark lineage
+
+A high-value historical era may eventually produce an Era Benchmark Pack:
+
+```text
+private era source
+→ integrity / provenance receipt
+→ historical observed cases
+→ public-safe replay cases
+→ rubric / oracle version
+→ historical score
+→ later bare-model reruns
+→ retrieval/runtime reruns
+→ mechanism labels
+→ intervention / correction history
+→ regression status
+```
+
+The purpose is not one global “smartness” ranking. The purpose is to ask which continuity or reliability dimensions improve, which failures recur across generations, and which gains come from the foundation model versus retrieval, context assembly or runtime support.
+
+## Public boundary
+
+The repository does not publish private L0/L1/L2 material. It publishes public-safe method cards and reproducible assets derived from reviewed sources.
+
+Public-safe outputs may include:
+
+```text
+anonymized / synthetic cases
+failure mechanisms
+rubrics / oracles
+protocols / schemas
+aggregate metrics
+mitigation specs
+regression evidence
+public-safe traces
+reproducible runners
+```
+
+Private source bodies, reverse-lookup archive locators, relationship/family records, medical/financial data, credentials, client material and other non-public evidence remain outside the repository.
+
+## Build / measure boundary
+
+The lineage also stops at the A1/A2 authority boundary:
+
+```text
+A1 / Companion-Mind
+= owns implementation and internal conformance
+
+A2 / LLM Evaluation Lab
+= owns independent cases, evidence, comparisons and gate verdicts
+```
+
+A2 may prove that an observable protection works or fails. It does not become a second owner of A1 runtime state, schemas, Persona, Relationship or Current truth.

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -1,10 +1,29 @@
 # Methodology
 
-The lab predeclares case inputs, expected behavior and metrics before comparing baseline and treatment.
+LLM Evaluation Lab treats evaluation as a failure-science and evidence discipline, not as a single score attached after implementation.
+
+The long-term method is:
 
 ```text
-Observe → Diagnose → Intervene → Stress-test → Measure → Regression-test
+Observed Failure / Friction
+→ Phenomenon Classification
+→ Mechanism Hypothesis / Cluster
+→ Reproducible Case
+→ Rubric / Oracle
+→ Baseline
+→ Mitigation Hypothesis
+→ Independent Verification / Falsification
+→ Regression
+→ Cross-Method Comparison
+→ Review
+→ Best-Known Solution
 ```
+
+The lab predeclares case inputs, expected behavior, oracle/rubric, relevant invariants and metrics before comparing baseline and treatment. A missing required observation is not a pass. `BLOCKED` and `NOT EVALUABLE` remain distinct from `PASS`.
+
+## 1. Reproduce before repairing
+
+A fluent explanation of a failure is not enough. Before accepting a mitigation, the lab tries to freeze a minimal case that reproduces the observable failure under controlled conditions.
 
 The first artifact uses invariant transformations: child wording and order change while the required closure decision does not. A valid treatment must also preserve the sensitive all-terminal case, avoiding the trivial strategy “never close anything.”
 
@@ -17,44 +36,261 @@ The historical benchmark adds a second construction method:
 5. validate the pair with one uniform evidence-and-constraint policy;
 6. scan the public fixture for private locators before release.
 
-The 89 observations are therefore evidence for clustering, not 89 executable rules.
-The reference gate has no mechanism-specific branch and never reads the expected
-label. A new mechanism can use the same gate when it exposes evidence state and
-explicit constraint statuses.
+The 89 observations are therefore evidence for clustering, not 89 executable rules. The reference gate has no mechanism-specific branch and never reads the expected label. A new mechanism can use the same gate when it exposes evidence state and explicit constraint statuses.
 
-Future model-based runs will keep the same separation between case owner, policy under test, grader, mitigation and checked-in result.
+## 2. Separate phenomenon from mechanism
 
-## Experiment records
+A user-visible failure is not automatically its root cause.
 
-An experiment run is immutable evidence, not a mutable dashboard row. The SQLite
-store uses `run_id` as the primary key and rejects duplicate IDs. Every record
-keeps the case-suite identity, model or policy, prompt version, git commit, UTC
-timestamp, latency, token cost, baseline and treatment accuracy, regression
-status, and canonical result JSON. Listing returns indexed metadata without
-dumping the stored result payload.
+Example phenomenon labels include:
 
-Structured lifecycle logs use one JSON object per line and remain separate from
-the report channel: `run_started`, `run_completed`, `run_persisted`, or
-`run_failed`. This preserves machine-readable observability without changing the
-deterministic report contract when tracking is not requested.
+```text
+wrong answer
+forgot constraint
+persona drift
+false shared history
+missed correction
+wrong source
+premature closure
+duplicate action
+silent state loss
+bad initiative
+```
 
-## Read-only query boundary
+Candidate mechanism labels may instead include:
 
-The FastAPI surface is a projection over immutable SQLite evidence. It opens the
-database in URI `mode=ro`, enables SQLite `query_only`, and exposes only health,
-metadata-list, and single-run-detail GET routes. List responses omit the stored
-result payload; detail responses return the canonical result for one run. Tests
-hash the database before and after all three queries to prove the query path does
-not mutate the evidence file.
+```text
+insufficient evidence grounding
+constraint omission
+context eviction
+retrieval miss
+retrieval contamination
+authority confusion
+state projection error
+identity binding failure
+provider adapter failure
+non-idempotent retry
+premature terminalization
+unsupported inference from UNKNOWN
+```
 
-## Container reproduction
+One phenomenon may map to multiple candidate mechanisms. A mechanism is promoted only when evidence discriminates it from plausible alternatives.
 
-The Docker image fixes the Companion-Mind runtime to an explicit commit, copies
-only the executable public-safe fixture and schema directories, installs the lab
-in editable mode so checked fixtures remain addressable, and drops privileges to
-UID 10001. CI treats the image as a black box: it verifies the version, executes
-the historical regression, writes one SQLite run through a mounted directory,
-then starts the API with that directory mounted read-only and queries it over HTTP.
+This matters because the object under evaluation is broader than a foundation model. A failure may originate in:
 
-The Python base tag and transitive package resolution are not locked by digest;
-this is repeatable functional packaging, not bit-for-bit image reproducibility.
+```text
+LLM reasoning or knowledge
+instruction following
+context assembly
+retrieval / authority routing
+tooling / provider adapters
+durable state / journal semantics
+persona / relationship continuity
+model switching
+crash / restart recovery
+longitudinal workflow orchestration
+```
+
+The lab does not force every system failure into a “model quality” explanation.
+
+## 3. Mitigation is a falsifiable hypothesis
+
+A mitigation is not accepted merely because one output looks better. It should imply a measurable change in the frozen failure condition.
+
+A high-value case should try to answer:
+
+```text
+What failed?
+Under what conditions?
+What evidence rules out alternative causes?
+What is the minimum reproducible case?
+What mechanism hypothesis explains it?
+What intervention should change the outcome?
+What result would falsify that hypothesis?
+Does the mitigation preserve matched controls?
+Does the old failure recur after unrelated changes?
+```
+
+A mitigation may be a prompt/instruction change, retrieval rule, schema/contract, state guard, context policy, runtime check, provider normalization, human-review gate, or another bounded intervention. “Mitigation” does not mean “prompt patch.”
+
+The lab should compare benefit against complexity, latency, cost and side effects.
+
+## 4. Falsification is as important as PASS
+
+A good evaluation does not only seek confirming examples. It should actively look for results that would show the mechanism hypothesis or mitigation is wrong.
+
+Useful falsification patterns include:
+
+- matched controls that should remain unchanged;
+- boundary cases that distinguish two candidate mechanisms;
+- reintroduction of a known-bad policy;
+- perturbations unrelated to the proposed causal mechanism;
+- replay on a different implementation that preserves the same public contract;
+- model/provider swaps where provider failure must not be mislabeled as behavioral quality.
+
+If the required seam, evidence or observation is missing, the correct verdict is `BLOCKED` or `NOT EVALUABLE`, not a guessed PASS or FAIL.
+
+## 5. Regression is part of the mitigation
+
+A failure being fixed once does not close the evidence loop.
+
+Accepted mitigations should, where practical, retain:
+
+- the original reproduction;
+- matched controls;
+- a known-bad recurrence variant;
+- version / commit identity;
+- stable fixture and result fingerprints;
+- a regression gate;
+- links to later recurrences.
+
+Longitudinal evidence makes a stronger question possible:
+
+> Does the same mechanism recur weeks or months later, after model changes, runtime changes, retrieval changes, or unrelated refactors?
+
+That produces a longitudinal regression corpus rather than a one-time benchmark snapshot.
+
+## 6. Historical evidence: observation is not replay
+
+Private historical Raw/L0 has two different evaluation uses and they must not be conflated.
+
+### Historical Observed Baseline
+
+Score what an older system actually did using a later frozen rubric.
+
+This has strong naturalistic value, but the historical model build, hidden system behavior, platform memory, context truncation and tool environment may not be reconstructable exactly. It is therefore historical observation, not a strict rerunnable causal experiment.
+
+### Frozen Replay Benchmark
+
+Extract and sanitize the necessary user task, visible context, constraints, relevant corrections, source evidence and rubric/oracle into a replayable case pack. Later models, retrieval configurations or runtimes can then run against the same frozen case.
+
+The distinction should be preserved in every evidence record:
+
+```text
+historical observed result ≠ replay result
+```
+
+A future Era Benchmark Pack may contain both, but must label them separately and preserve the known limitations of each.
+
+## 7. RAW Harvest: archive completion is not evaluation completion
+
+Recovered longitudinal material has two completion states:
+
+```text
+Archive Complete
+= recovery + integrity/provenance checks + source/time boundary + archive
+
+Eval Harvest Complete
+= candidate selection
+  → mechanism classification
+  → anonymization / synthetic abstraction
+  → rubric / oracle
+  → baseline
+  → mitigation
+  → falsification
+  → regression
+  → longitudinal comparison
+  → best-known solution
+```
+
+Not every conversation should become a case. Prefer material that is generalizable, reproducible, mechanism-bearing, contrastable, regression-worthy, and grounded by corrections, later outcomes or other source evidence.
+
+Private Raw/L0 is the evidence mine, not the public dataset.
+
+## 8. A1 conformance and A2 black-box evaluation
+
+A1 / Companion-Mind builds the system and owns implementation authority. A2 measures observable behavior independently.
+
+A1 owns, among other things:
+
+- production/runtime implementation;
+- internal storage mechanics;
+- the canonical event contract authority;
+- sanctioned fault hooks / test seams;
+- implementation-specific conformance checks.
+
+A2 owns:
+
+- independent manifests;
+- cases, rubrics and oracles;
+- black-box observations;
+- normalized evidence registries;
+- comparative metrics;
+- independent gate verdicts.
+
+A2 must not copy A1 schema into a second authority or mutate Current, Persona or Relationship truth. A1 internal conformance and A2 external evidence are complementary; neither substitutes for the other.
+
+## 9. Current product-linked gate: A019 / E1
+
+The nearest product-linked evaluation target is the Durable Journal black-box gate.
+
+The approved Wave 1 plan defines the observable dimensions:
+
+```text
+Durability
+Ordering
+Dedupe
+Crash Recovery
+Restart Recovery
+Correction
+Secret Exclusion
+UNKNOWN Semantics
+```
+
+Gate E1 is an all-of gate. Zero-tolerance failures are not averaged into a score. Execution requires the separately authorized A2 harness work plus an A1-D candidate and sanctioned public seam.
+
+Later evaluation grows with the system under test:
+
+```text
+Journal / E1
+→ Context Engine / Owned Home
+→ Retrieval / Authority Routing
+→ Model Gateway / model-switch continuity
+→ W1 operational independence
+→ Living Lab longitudinal reliability
+→ W2 evidence readiness
+```
+
+The lab should not pre-build large empty benchmark structures for stages that do not yet expose a stable testable seam.
+
+## 10. Experiment records
+
+An experiment run is immutable evidence, not a mutable dashboard row. The SQLite store uses `run_id` as the primary key and rejects duplicate IDs. Every record keeps the case-suite identity, model or policy, prompt version, git commit, UTC timestamp, latency, token cost, baseline and treatment accuracy, regression status, and canonical result JSON. Listing returns indexed metadata without dumping the stored result payload.
+
+For historical or era-derived studies, the evidence registry should additionally distinguish:
+
+```text
+source era
+historical observation vs replay
+anonymization transform
+private-source access boundary
+correction / intervention linkage
+known limitations / UNKNOWNs
+```
+
+Structured lifecycle logs use one JSON object per line and remain separate from the report channel: `run_started`, `run_completed`, `run_persisted`, or `run_failed`. This preserves machine-readable observability without changing the deterministic report contract when tracking is not requested.
+
+## 11. Read-only query boundary
+
+The FastAPI surface is a projection over immutable SQLite evidence. It opens the database in URI `mode=ro`, enables SQLite `query_only`, and exposes only health, metadata-list, and single-run-detail GET routes. List responses omit the stored result payload; detail responses return the canonical result for one run. Tests hash the database before and after all three queries to prove the query path does not mutate the evidence file.
+
+## 12. Container reproduction
+
+The Docker image fixes the Companion-Mind runtime to an explicit commit, copies only the executable public-safe fixture and schema directories, installs the lab in editable mode so checked fixtures remain addressable, and drops privileges to UID 10001. CI treats the image as a black box: it verifies the version, executes the historical regression, writes one SQLite run through a mounted directory, then starts the API with that directory mounted read-only and queries it over HTTP.
+
+The Python base tag and transitive package resolution are not locked by digest; this is repeatable functional packaging, not bit-for-bit image reproducibility.
+
+## 13. Claims boundary
+
+A benchmark result is evidence under a frozen protocol, not an automatic scientific conclusion.
+
+The current repository does not claim:
+
+- scientific benchmark validity;
+- corpus representativeness;
+- broad model generalization;
+- live-model statistical significance;
+- production or enterprise evaluation readiness;
+- objective ground truth for personality, relationship, consciousness or subjective experience.
+
+The methodology is deliberately stricter than the claim: preserve what is known, mark what is not evaluable, and make future reruns able to challenge today's best-known explanation.


### PR DESCRIPTION
## What changed

Docs-only synchronization of the public Eval Lab narrative with the current EVAL-REPO v1.0 construction authority.

- refreshes `README.md` from the stale Persistent-AI-Companion / Day-1-7-30-90 framing to the current A2 mission and A019/E1 placement;
- refreshes `README.zh-CN.md` from the older “third repository” framing to A2 / Measure the system;
- expands `docs/methodology.md` into the current failure-science loop: phenomenon → mechanism → reproduction → oracle → baseline → mitigation → falsification → regression → best-known solution;
- expands `docs/method-lineage.md` with Archive Complete vs Eval Harvest Complete, Historical Observed Baseline vs Frozen Replay, and Era Benchmark lineage;
- adds `docs/current-roadmap.md` covering the four current lanes: Failure Mechanism Lab, A2 Independent System Gates, RAW Harvest / Era Benchmarks, and Longitudinal Cognitive / Persona Research.

## Why

The executable evidence base is still valid, but the public narrative had drifted behind the current personal-first Companion-Mind roadmap and behind the actual Eval Lab methodology already embodied by the Historical Failure Benchmark and A2 Wave 1 plan.

The immediate product-linked evaluation target is now A019 / Gate E1 black-box durability. After E1, evaluation follows Context/Owned Home → W1 → Living Lab → W2. No commercial companion product is pre-selected.

## Boundaries

- docs only; no code, schema, fixtures, tests, Docker or workflow changes;
- no change to existing First Closed Loop / Historical Failure Benchmark results or evidence claims;
- no modification of the already accepted A2 Wave 1 stage-plan record;
- no A2 implementation authorization, no Gate E1 execution authorization, and no live/paid model work;
- private Raw/L0 remains private; historical/era benchmark material is described only as a public-safe future evaluation lane.

## Validation

- branch is based on current `main` commit `ac437c597d0ead748bd1939f6cf8b5d686508a87`;
- compare shows exactly five documentation paths changed and zero code/schema/test changes;
- CI status will be recorded on this exact head before review.